### PR TITLE
カスタムフィールドでの条件分岐機能を追加

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: dynamic, block, if, front page, single
 Requires at least: 6.0
 Tested up to: 6.2
 Requires PHP: 7.4
-Stable tag: 0.3.1
+Stable tag: 0.4.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -34,6 +34,9 @@ However, by nesting Dynamic If Blocks, various conditional branching can be hand
 3. Dynamic If block in the site editor.
 
 == Changelog ==
+
+= 0.4.0 =
+* Add custom field conditions
 
 = 0.3.1 =
 * Fix translate

--- a/src/block.json
+++ b/src/block.json
@@ -13,6 +13,18 @@
 			"type": "string",
 			"default": "none"
 		},
+		"customFieldName": {
+			"type": "string",
+			"default": ""
+		},
+		"customFieldRule": {
+			"type": "string",
+			"default": ""
+		},
+		"customFieldValue": {
+			"type": "string",
+			"default": ""
+		},
 		"exclusion": {
 			"type": "boolean",
 			"default": false

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,12 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, InnerBlocks, InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
+import { 
+	PanelBody, 
+	SelectControl, 
+	TextControl,
+	ToggleControl 
+} from '@wordpress/components';
 import { ReactComponent as Icon } from './icon.svg';
 
 registerBlockType('vk-blocks/dynamic-if', {
@@ -18,6 +23,18 @@ registerBlockType('vk-blocks/dynamic-if', {
 			type: 'string',
 			default: 'none',
 		},
+		customFieldName: {
+			type: 'string',
+			"default": ""
+		},
+		customFieldRule: {
+			type: 'string',
+			"default": ""
+		},
+		customFieldValue: {
+			type: 'string',
+			"default": ""
+		},
 		exclusion: {
 			type: 'boolian',
 			default: false,
@@ -28,7 +45,7 @@ registerBlockType('vk-blocks/dynamic-if', {
 		innerBlocks: true,
 	},
 	edit({ attributes, setAttributes }) {
-		const { ifPageType, ifPostType, exclusion } = attributes;
+		const { ifPageType, ifPostType, customFieldName, customFieldRule, customFieldValue, exclusion } = attributes;
 
 		const ifPageTypes = [
 			{ value: 'none', label: __('No restriction', 'vk-dynamic-if-block') },
@@ -69,6 +86,29 @@ registerBlockType('vk-blocks/dynamic-if', {
 							value={ifPostType}
 							options={vk_dynamic_if_block_localize_data.postTypeSelectOptions}
 							onChange={(value) => setAttributes({ ifPostType: value })}
+						/>
+						<TextControl
+							label={__('Custom Field Name', 'vk-dynamic-if-block')}
+							value={customFieldName}
+							onChange={(value) =>
+								setAttributes({ customFieldName: value })
+							}
+						/>
+						<SelectControl
+							label={__('Custom Field Rule', 'vk-dynamic-if-block')}
+							value={customFieldRule}
+							options={[
+								{ value: 'valueExists', label: __('Value Exist ( !empty() )', 'vk-dynamic-if-block') },
+								{ value: 'valueEquals', label: __('Value Equals ( === )', 'vk-dynamic-if-block') },
+							]}
+							onChange={(value) => setAttributes({ customFieldRule: value })}
+						/>
+						<TextControl
+							label={__('Custom Field Name', 'vk-dynamic-if-block')}
+							value={customFieldValue}
+							onChange={(value) =>
+								setAttributes({ customFieldValue: value })
+							}
 						/>
 						<ToggleControl
 							label={__('Exclusion designation', 'vk-dynamic-if-block')}

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, InnerBlocks, InspectorControls } from '@wordpress/block-editor';
-import { 
-	PanelBody, 
-	SelectControl, 
+import {
+	PanelBody,
+	SelectControl,
 	TextControl,
-	ToggleControl 
+	ToggleControl
 } from '@wordpress/components';
 import { ReactComponent as Icon } from './icon.svg';
 
@@ -69,7 +69,7 @@ registerBlockType('vk-blocks/dynamic-if', {
 
 		const blockClassName = `vk-dynamic-if-block ifPageType-${ifPageType} ifPostType-${ifPostType}`;
 		const MY_TEMPLATE = [
-			[ 'core/paragraph', {} ],
+			['core/paragraph', {}],
 		];
 		return (
 			<div {...useBlockProps({ className: blockClassName })}>
@@ -94,22 +94,31 @@ registerBlockType('vk-blocks/dynamic-if', {
 								setAttributes({ customFieldName: value })
 							}
 						/>
-						<SelectControl
-							label={__('Custom Field Rule', 'vk-dynamic-if-block')}
-							value={customFieldRule}
-							options={[
-								{ value: 'valueExists', label: __('Value Exist ( !empty() )', 'vk-dynamic-if-block') },
-								{ value: 'valueEquals', label: __('Value Equals ( === )', 'vk-dynamic-if-block') },
-							]}
-							onChange={(value) => setAttributes({ customFieldRule: value })}
-						/>
-						<TextControl
-							label={__('Custom Field Value', 'vk-dynamic-if-block')}
-							value={customFieldValue}
-							onChange={(value) =>
-								setAttributes({ customFieldValue: value })
-							}
-						/>
+						{customFieldName && (
+							<>
+								<SelectControl
+									label={__('Custom Field Rule', 'vk-dynamic-if-block')}
+									value={customFieldRule}
+									options={[
+										{ value: 'valueExists', label: __('Value Exist ( !empty() )', 'vk-dynamic-if-block') },
+										{ value: 'valueEquals', label: __('Value Equals ( === )', 'vk-dynamic-if-block') },
+									]}
+									onChange={(value) => setAttributes({ customFieldRule: value })}
+								/>
+								{customFieldRule === 'valueEquals' && (
+									<>
+										<TextControl
+											label={__('Custom Field Value', 'vk-dynamic-if-block')}
+											value={customFieldValue}
+											onChange={(value) =>
+												setAttributes({ customFieldValue: value })
+											}
+										/>
+									</>
+								)}
+							</>
+						)}
+
 						<ToggleControl
 							label={__('Exclusion designation', 'vk-dynamic-if-block')}
 							checked={exclusion}
@@ -120,8 +129,8 @@ registerBlockType('vk-blocks/dynamic-if', {
 				<div className="vk-dynamic-if-block__label">{ifPageType} / {ifPostType}</div>
 
 				<InnerBlocks
-					template={ MY_TEMPLATE }
-				 />
+					template={MY_TEMPLATE}
+				/>
 			</div>
 		);
 	},

--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,7 @@ registerBlockType('vk-blocks/dynamic-if', {
 							onChange={(value) => setAttributes({ customFieldRule: value })}
 						/>
 						<TextControl
-							label={__('Custom Field Name', 'vk-dynamic-if-block')}
+							label={__('Custom Field Value', 'vk-dynamic-if-block')}
 							value={customFieldValue}
 							onChange={(value) =>
 								setAttributes({ customFieldValue: value })

--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,23 @@ registerBlockType('vk-blocks/dynamic-if', {
 		const MY_TEMPLATE = [
 			['core/paragraph', {}],
 		];
+
+		let labels = [];
+
+		if (ifPageType !== "none") {
+			labels.push(ifPageType);
+		}
+
+		if (ifPostType !== "none") {
+			labels.push(ifPostType);
+		}
+
+		if (customFieldName) {
+			labels.push(customFieldName);
+		}
+
+		let labels_string = labels.join(" / ");
+
 		return (
 			<div {...useBlockProps({ className: blockClassName })}>
 				<InspectorControls>
@@ -126,7 +143,7 @@ registerBlockType('vk-blocks/dynamic-if', {
 						/>
 					</PanelBody>
 				</InspectorControls>
-				<div className="vk-dynamic-if-block__label">{ifPageType} / {ifPostType}</div>
+				<div className="vk-dynamic-if-block__label">{labels_string}</div>
 
 				<InnerBlocks
 					template={MY_TEMPLATE}

--- a/src/index.php
+++ b/src/index.php
@@ -15,6 +15,9 @@ use VektorInc\VK_Helpers\VkHelpers;
 function vk_dynamic_if_block_render( $attributes, $content ) {
 	$page_type = isset( $attributes['ifPageType'] ) ? $attributes['ifPageType'] : 'none';
 	$post_type = isset( $attributes['ifPostType'] ) ? $attributes['ifPostType'] : 'none';
+	$post_type = isset( $attributes['customFieldName'] ) ? $attributes['customFieldName'] : '';
+	$post_type = isset( $attributes['customFieldRule'] ) ? $attributes['customFieldRule'] : '';
+	$post_type = isset( $attributes['customFieldValue'] ) ? $attributes['customFieldValue'] : '';
 	$exclusion = isset( $attributes['exclusion'] ) ? $attributes['exclusion'] : false;
 
 	$display = '';

--- a/src/index.php
+++ b/src/index.php
@@ -13,12 +13,15 @@ use VektorInc\VK_Helpers\VkHelpers;
  * @return string $return : Return HTML.
  */
 function vk_dynamic_if_block_render( $attributes, $content ) {
-	$page_type = isset( $attributes['ifPageType'] ) ? $attributes['ifPageType'] : 'none';
-	$post_type = isset( $attributes['ifPostType'] ) ? $attributes['ifPostType'] : 'none';
-	$cf_name   = isset( $attributes['customFieldName'] ) ? $attributes['customFieldName'] : '';
-	$cf_rule   = ! empty( $attributes['customFieldRule'] ) ? $attributes['customFieldRule'] : 'valueExists';
-	$cf_value  = isset( $attributes['customFieldValue'] ) ? $attributes['customFieldValue'] : '';
-	$exclusion = isset( $attributes['exclusion'] ) ? $attributes['exclusion'] : false;
+	$attributes_default = array(
+		'ifPageType'       => 'none',
+		'ifPostType'       => 'none',
+		'customFieldName'  => '',
+		'customFieldRule'  => 'valueExists',
+		'customFieldValue' => '',
+		'exclusion'        => false,
+	);
+	$attributes         = array_merge( $attributes_default, $attributes );
 
 	$display = false;
 
@@ -27,23 +30,23 @@ function vk_dynamic_if_block_render( $attributes, $content ) {
 	$display_by_page_type = false;
 
 	if (
-		is_front_page() && 'is_front_page' === $page_type ||
-		is_single() && 'is_single' === $page_type ||
-		is_page() && 'is_page' === $page_type ||
-		is_singular() && 'is_singular' === $page_type ||
-		is_home() && ! is_front_page() && 'is_home' === $page_type ||
-		is_post_type_archive() && 'is_post_type_archive' === $page_type ||
-		is_category() && 'is_category' === $page_type ||
-		is_tag() && 'is_tag' === $page_type ||
-		is_tax() && 'is_tax' === $page_type ||
-		is_year() && 'is_year' === $page_type ||
-		is_month() && 'is_month' === $page_type ||
-		is_date() && 'is_date' === $page_type ||
-		is_author() && 'is_author' === $page_type ||
-		is_search() && 'is_search' === $page_type ||
-		is_404() && 'is_404' === $page_type ||
-		is_archive() && 'is_archive' === $page_type ||
-		'none' === $page_type
+		is_front_page() && 'is_front_page' === $attributes['ifPageType'] ||
+		is_single() && 'is_single' === $attributes['ifPageType'] ||
+		is_page() && 'is_page' === $attributes['ifPageType'] ||
+		is_singular() && 'is_singular' === $attributes['ifPageType'] ||
+		is_home() && ! is_front_page() && 'is_home' === $attributes['ifPageType'] ||
+		is_post_type_archive() && 'is_post_type_archive' === $attributes['ifPageType'] ||
+		is_category() && 'is_category' === $attributes['ifPageType'] ||
+		is_tag() && 'is_tag' === $attributes['ifPageType'] ||
+		is_tax() && 'is_tax' === $attributes['ifPageType'] ||
+		is_year() && 'is_year' === $attributes['ifPageType'] ||
+		is_month() && 'is_month' === $attributes['ifPageType'] ||
+		is_date() && 'is_date' === $attributes['ifPageType'] ||
+		is_author() && 'is_author' === $attributes['ifPageType'] ||
+		is_search() && 'is_search' === $attributes['ifPageType'] ||
+		is_404() && 'is_404' === $attributes['ifPageType'] ||
+		is_archive() && 'is_archive' === $attributes['ifPageType'] ||
+		'none' === $attributes['ifPageType']
 	) {
 		$display_by_page_type = true;
 	}
@@ -61,9 +64,9 @@ function vk_dynamic_if_block_render( $attributes, $content ) {
 		$post_type_slug = get_post_type();
 	}
 
-	if ( 'none' === $post_type ) {
+	if ( 'none' === $attributes['ifPostType'] ) {
 		$display_by_post_type = true;
-	} elseif ( $post_type_slug === $post_type ) {
+	} elseif ( $post_type_slug === $attributes['ifPostType'] ) {
 		$display_by_post_type = true;
 	} else {
 		$display_by_post_type = false;
@@ -73,20 +76,20 @@ function vk_dynamic_if_block_render( $attributes, $content ) {
 
 	$display_by_custom_field = false;
 
-	if ( ! $cf_name ) {
+	if ( ! $attributes['customFieldName'] ) {
 		$display_by_custom_field = true;
-	} elseif ( $cf_name ) {
+	} elseif ( $attributes['customFieldName'] ) {
 
 		if ( get_the_ID() ) {
-			$get_value = get_post_meta( get_the_ID(), $cf_name, true );
-			if ( 'valueExists' === $cf_rule ) {
+			$get_value = get_post_meta( get_the_ID(), $attributes['customFieldName'], true );
+			if ( 'valueExists' === $attributes['customFieldRule'] ) {
 				if ( $get_value || '0' === $get_value ) {
 					$display_by_custom_field = true;
 				} else {
 					$display_by_custom_field = false;
 				}
-			} elseif ( 'valueEquals' === $cf_rule ) {
-				if ( $get_value === $cf_value ) {
+			} elseif ( 'valueEquals' === $attributes['customFieldRule'] ) {
+				if ( $get_value === $attributes['customFieldValue'] ) {
 					$display_by_custom_field = true;
 				} else {
 					$display_by_custom_field = false;
@@ -106,7 +109,7 @@ function vk_dynamic_if_block_render( $attributes, $content ) {
 	 *
 	 * @since 0.3.0
 	 */
-	if ( $exclusion ) {
+	if ( $attributes['exclusion'] ) {
 		$display = ! $display;
 	}
 

--- a/tests/test-dynamic-if.php
+++ b/tests/test-dynamic-if.php
@@ -485,20 +485,113 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase {
 			 *
 			 * @since 0.4.0 */
 
-			// URLで home_url() . /non-exist-page/ にアクセスしてもサーバー側で Not Found にされてしまい WordPressの 404 にならないため
-			// home_url() . '/?cat=999999' で指定している
 			array(
 				'name'      => 'Custom Field Exist',
-				'go_to'     => home_url() . '/?cat=999999',
+				'go_to'     => get_permalink( $test_posts['event_post_id'] ),
 				'attribute' => array(
 					'ifPageType'       => 'none',
 					'ifPostType'       => 'none',
 					'CustomFieldName'  => 'price',
-					'customFieldRule'  => '',
+					'customFieldRule'  => 'valueExists',
 					'customFieldValue' => '',
 				),
-				'content'   => '100',
-				'expected'  => '100',
+				'test_meta' => array(
+					'post_id'    => $test_posts['event_post_id'],
+					'meta_key'   => 'price',
+					'meta_value' => '100',
+				),
+				'content'   => 'Custom Field Exist',
+				'expected'  => 'Custom Field Exist',
+			),
+			array(
+				'name'      => 'Custom Field no value',
+				'go_to'     => get_permalink( $test_posts['event_post_id'] ),
+				'attribute' => array(
+					'ifPageType'       => 'none',
+					'ifPostType'       => 'none',
+					'customFieldName'  => 'price',
+					'customFieldRule'  => 'valueExists',
+					'customFieldValue' => '',
+				),
+				'test_meta' => array(
+					'post_id'    => $test_posts['event_post_id'],
+					'meta_key'   => 'price',
+					'meta_value' => '',
+				),
+				'content'   => 'Custom Field Exist',
+				'expected'  => '',
+			),
+			array(
+				'name'      => 'Custom Field value exist string 0',
+				'go_to'     => get_permalink( $test_posts['event_post_id'] ),
+				'attribute' => array(
+					'ifPageType'       => 'none',
+					'ifPostType'       => 'none',
+					'customFieldName'  => 'price',
+					'customFieldRule'  => 'valueExists',
+					'customFieldValue' => '',
+				),
+				'test_meta' => array(
+					'post_id'    => $test_posts['event_post_id'],
+					'meta_key'   => 'price',
+					'meta_value' => '0',
+				),
+				'content'   => '0',
+				'expected'  => '0',
+			),
+			array(
+				'name'      => 'Custom Field value exist number 0',
+				'go_to'     => get_permalink( $test_posts['event_post_id'] ),
+				'attribute' => array(
+					'ifPageType'       => 'none',
+					'ifPostType'       => 'none',
+					'customFieldName'  => 'price',
+					'customFieldRule'  => 'valueExists',
+					'customFieldValue' => '',
+				),
+				'test_meta' => array(
+					'post_id'    => $test_posts['event_post_id'],
+					'meta_key'   => 'price',
+					'meta_value' => 0,
+				),
+				'content'   => '0',
+				'expected'  => '0',
+			),
+			array(
+				'name'      => 'Custom Field value match',
+				'go_to'     => get_permalink( $test_posts['event_post_id'] ),
+				'attribute' => array(
+					'ifPageType'       => 'none',
+					'ifPostType'       => 'none',
+					'customFieldName'  => 'price',
+					'customFieldRule'  => 'valueEquals',
+					'customFieldValue' => '100',
+				),
+				'test_meta' => array(
+					'post_id'    => $test_posts['event_post_id'],
+					'meta_key'   => 'price',
+					'meta_value' => '100',
+				),
+				'content'   => 'Custom Field value match',
+				'expected'  => 'Custom Field value match',
+			),
+			array(
+				'name'      => 'Custom Field value not match',
+				'go_to'     => get_permalink( $test_posts['event_post_id'] ),
+				'attribute' => array(
+					'ifPageType'       => 'none',
+					'ifPostType'       => 'none',
+					'customFieldName'  => 'price',
+					'customFieldRule'  => 'valueEquals',
+					'customFieldValue' => '100',
+				),
+				'test_meta' => array(
+					'post_id'    => $test_posts['event_post_id'],
+					'meta_key'   => 'price',
+					'meta_value' => '',
+				),
+				'content'   => 'Custom Field value not match',
+				'expected'  => '',
 			),
 		);
 
@@ -510,11 +603,23 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase {
 				}
 			}
 
+			if ( isset( $test['test_meta'] ) && isset( $test['test_meta']['post_id'] ) ) {
+				update_post_meta(
+					$test['test_meta']['post_id'],
+					$test['test_meta']['meta_key'],
+					$test['test_meta']['meta_value']
+				);
+			}
+
 			print PHP_EOL;
 			$this->go_to( $test['go_to'] );
 			$actual = vk_dynamic_if_block_render( $test['attribute'], $test['content'] );
+
 			print 'Page : ' . esc_html( $test['name'] ) . PHP_EOL;
 			print 'go_to : ' . esc_html( $test['go_to'] ) . PHP_EOL;
+			if ( isset( $test['test_meta'] ) && isset( $test['test_meta']['post_id'] ) ) {
+				print 'meta : ' . esc_html( get_post_meta( $test['test_meta']['post_id'], $test['test_meta']['meta_key'], true ) ) . PHP_EOL;
+			}
 			$this->assertSame( $test['expected'], $actual, $test['name'] );
 
 			if ( isset( $test['options'] ) ) {

--- a/vk-dynamic-if-block.php
+++ b/vk-dynamic-if-block.php
@@ -5,8 +5,8 @@
  * Description: A dynamic block that shows its inner blocks based on specified conditions, such as whether the current page is the front page or a single post.
  * Author: Vektor,Inc.
  * Author URI: https://vektor-inc.co.jp/en/
- * Version: 0.3.1
- * Stable tag: 0.3.1
+ * Version: 0.4.0
+ * Stable tag: 0.4.0
  * License: GPL-2.0-or-later
  * Text Domain: vk-dynamic-if-block
  *


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

カスタムフィールドで、値がある場合だけ表示したいケースがある。
例えば、

料金 : 400円

という表示をしたい場合、カスタムフィールドの値の部分は 400 とすると、
入力がなかった場合の表示は

料金 : 円

になってしまう。

■ 関連
https://github.com/vektor-inc/vk-dynamic-if-block/issues/20

## どういう変更をしたか？

指定したカスタムフィールドに値がある場合の条件分岐が可能になります。
また、カスタムフィールドの値が指定のものを等しい場合も条件分岐が可能になります。

![スクリーンショット 2023-07-04 7 04 33](https://github.com/vektor-inc/vk-dynamic-if-block/assets/3272660/b7223df7-b4db-44e5-a37b-de883fe552ae)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

PHPUnit
* wp-env start
* npm run phpunit

操作テスト
* カスタムフィールドを適当に作成
* 個別テンプレート / 投稿ループ内に Dynamic If ブロックを配置、カスタムフィールド名を入力
* Rule を Value Exisit に指定 
* カスタムフィールドの値を入れてインナーブロック内の要素が表示されるか確認
* 値を削除して保存、インナーブロック内の要素が非表示になる事を確認
* 数字の 0 を入力して保存
* インナーブロック内の要素が表示される事を確認
* Rule を  Value Equal に変更し、CUSTOM FIELD VALUE を 100 に指定
* 投稿のカスタムフィールドの値に 100 を入力して保存
* インナーブロック内の要素が表示される事を確認

## 確認URL

ローカルでよろしくお願いいたします。

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* 実装者に同じ
* ソースコードの処理で何か問題がないか

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？

