### PR TITLE
【二人目確認中】ログインユーザーにのみ表示されるオプションを追加

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,7 @@ However, by nesting Dynamic If Blocks, various conditional branching can be hand
 
 == Changelog ==
 
+[ Add Function ] Added condition to display only to login user.
 [ Specification Change ]Fix WordPress 6.3 transforms settings.
 
 = 0.6.3 =

--- a/src/block.json
+++ b/src/block.json
@@ -48,6 +48,10 @@
 		"periodReferCustomField": {
 			"type": "string",
 			"default": ""
+		},
+		"showOnlyLoginUser": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,10 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
-import { useBlockProps, InnerBlocks, InspectorControls } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	InnerBlocks,
+	InspectorControls,
+} from '@wordpress/block-editor';
 import {
 	PanelBody,
 	SelectControl,
@@ -13,9 +17,9 @@ import {
 import { ReactComponent as Icon } from './icon.svg';
 import transforms from './transforms';
 
-registerBlockType('vk-blocks/dynamic-if', {
+registerBlockType( 'vk-blocks/dynamic-if', {
 	apiVersion: 2,
-	title: __('Dynamic If', 'vk-dynamic-if-block'),
+	title: __( 'Dynamic If', 'vk-dynamic-if-block' ),
 	icon: <Icon />,
 	transforms,
 	category: 'theme',
@@ -34,15 +38,15 @@ registerBlockType('vk-blocks/dynamic-if', {
 		},
 		customFieldName: {
 			type: 'string',
-			"default": ""
+			default: '',
 		},
 		customFieldRule: {
 			type: 'string',
-			"default": ""
+			default: '',
 		},
 		customFieldValue: {
 			type: 'string',
-			"default": ""
+			default: '',
 		},
 		exclusion: {
 			type: 'boolian',
@@ -50,239 +54,508 @@ registerBlockType('vk-blocks/dynamic-if', {
 		},
 		periodDisplaySetting: {
 			type: 'string',
-			"default": "none"
+			default: 'none',
 		},
 		periodSpecificationMethod: {
 			type: 'string',
-			"default": "direct"
+			default: 'direct',
 		},
 		periodDisplayValue: {
 			type: 'string',
-			"default": ""
+			default: '',
 		},
 		periodReferCustomField: {
 			type: 'string',
-			"default": ""
+			default: '',
+		},
+		showOnlyLoginUser: {
+			type: 'boolean',
+			default: false,
 		},
 	},
 	supports: {
 		html: false,
 		innerBlocks: true,
 	},
-	edit({ attributes, setAttributes }) {
-		const { ifPageType, ifPostType, userRole, customFieldName, customFieldRule, customFieldValue, exclusion, periodDisplaySetting, periodSpecificationMethod, periodDisplayValue, periodReferCustomField } = attributes;
+	edit( { attributes, setAttributes } ) {
+		const {
+			ifPageType,
+			ifPostType,
+			userRole,
+			customFieldName,
+			customFieldRule,
+			customFieldValue,
+			exclusion,
+			periodDisplaySetting,
+			periodSpecificationMethod,
+			periodDisplayValue,
+			periodReferCustomField,
+			showOnlyLoginUser,
+		} = attributes;
 
 		const ifPageTypes = [
-			{ value: 'none', label: __('No restriction', 'vk-dynamic-if-block') },
-			{ value: 'is_front_page', label: __('Front Page', 'vk-dynamic-if-block') + ' ( is_front_page() )' },
-			{ value: 'is_single', label: __('Single', 'vk-dynamic-if-block') + ' ( is_single() )' },
-			{ value: 'is_page', label: __('Page', 'vk-dynamic-if-block') + ' ( is_page() )' },
-			{ value: 'is_singular', label: __('Singular', 'vk-dynamic-if-block') + ' ( is_singular() )' },
-			{ value: 'is_home', label: __('Post Top', 'vk-dynamic-if-block') + ' ( is_home() && ! is_front_page() )' },
-			{ value: 'is_post_type_archive', label: __('Post Type Archive', 'vk-dynamic-if-block') + ' ( is_post_type_archive() )' },
-			{ value: 'is_category', label: __('Category Archive', 'vk-dynamic-if-block') + ' ( is_category() )' },
-			{ value: 'is_tag', label: __('Tag Archive', 'vk-dynamic-if-block') + ' ( is_tag() )' },
-			{ value: 'is_tax', label: __('Taxonomy Archive', 'vk-dynamic-if-block') + ' ( is_tax() )' },
-			{ value: 'is_year', label: __('Yearly Archive', 'vk-dynamic-if-block') + ' ( is_year() )' },
-			{ value: 'is_month', label: __('Monthly Archive', 'vk-dynamic-if-block') + ' ( is_month() )' },
-			{ value: 'is_date', label: __('Daily Archive', 'vk-dynamic-if-block') + ' ( is_date() )' },
-			{ value: 'is_author', label: __('Author Archive', 'vk-dynamic-if-block') + ' ( is_author() )' },
-			{ value: 'is_archive', label: __('Archive', 'vk-dynamic-if-block') + ' ( is_archive() )' },
-			{ value: 'is_search', label: __('Search Result', 'vk-dynamic-if-block') + ' ( is_search() )' },
-			{ value: 'is_404', label: __('404', 'vk-dynamic-if-block') + ' ( is_404() )' },
+			{
+				value: 'none',
+				label: __( 'No restriction', 'vk-dynamic-if-block' ),
+			},
+			{
+				value: 'is_front_page',
+				label:
+					__( 'Front Page', 'vk-dynamic-if-block' ) +
+					' ( is_front_page() )',
+			},
+			{
+				value: 'is_single',
+				label:
+					__( 'Single', 'vk-dynamic-if-block' ) + ' ( is_single() )',
+			},
+			{
+				value: 'is_page',
+				label: __( 'Page', 'vk-dynamic-if-block' ) + ' ( is_page() )',
+			},
+			{
+				value: 'is_singular',
+				label:
+					__( 'Singular', 'vk-dynamic-if-block' ) +
+					' ( is_singular() )',
+			},
+			{
+				value: 'is_home',
+				label:
+					__( 'Post Top', 'vk-dynamic-if-block' ) +
+					' ( is_home() && ! is_front_page() )',
+			},
+			{
+				value: 'is_post_type_archive',
+				label:
+					__( 'Post Type Archive', 'vk-dynamic-if-block' ) +
+					' ( is_post_type_archive() )',
+			},
+			{
+				value: 'is_category',
+				label:
+					__( 'Category Archive', 'vk-dynamic-if-block' ) +
+					' ( is_category() )',
+			},
+			{
+				value: 'is_tag',
+				label:
+					__( 'Tag Archive', 'vk-dynamic-if-block' ) +
+					' ( is_tag() )',
+			},
+			{
+				value: 'is_tax',
+				label:
+					__( 'Taxonomy Archive', 'vk-dynamic-if-block' ) +
+					' ( is_tax() )',
+			},
+			{
+				value: 'is_year',
+				label:
+					__( 'Yearly Archive', 'vk-dynamic-if-block' ) +
+					' ( is_year() )',
+			},
+			{
+				value: 'is_month',
+				label:
+					__( 'Monthly Archive', 'vk-dynamic-if-block' ) +
+					' ( is_month() )',
+			},
+			{
+				value: 'is_date',
+				label:
+					__( 'Daily Archive', 'vk-dynamic-if-block' ) +
+					' ( is_date() )',
+			},
+			{
+				value: 'is_author',
+				label:
+					__( 'Author Archive', 'vk-dynamic-if-block' ) +
+					' ( is_author() )',
+			},
+			{
+				value: 'is_archive',
+				label:
+					__( 'Archive', 'vk-dynamic-if-block' ) +
+					' ( is_archive() )',
+			},
+			{
+				value: 'is_search',
+				label:
+					__( 'Search Result', 'vk-dynamic-if-block' ) +
+					' ( is_search() )',
+			},
+			{
+				value: 'is_404',
+				label: __( '404', 'vk-dynamic-if-block' ) + ' ( is_404() )',
+			},
 		];
 
-		const blockClassName = `vk-dynamic-if-block ifPageType-${ifPageType} ifPostType-${ifPostType}`;
-		const MY_TEMPLATE = [
-			['core/paragraph', {}],
-		];
+		const blockClassName = `vk-dynamic-if-block ifPageType-${ ifPageType } ifPostType-${ ifPostType }`;
+		const MY_TEMPLATE = [ [ 'core/paragraph', {} ] ];
 
 		const userRolesObj = vk_dynamic_if_block_localize_data.userRoles || {};
-		const userRoles = Object.keys(userRolesObj).map(key => ({
+		const userRoles = Object.keys( userRolesObj ).map( ( key ) => ( {
 			value: key,
-			label: __(userRolesObj[key], 'vk-dynamic-if-block'),
-		}));
+			label: __( userRolesObj[ key ], 'vk-dynamic-if-block' ),
+		} ) );
 
 		let labels = [];
 
-		if (ifPageType !== "none") {
-			labels.push(ifPageType);
+		if ( ifPageType !== 'none' ) {
+			labels.push( ifPageType );
 		}
 
-		if (ifPostType !== "none") {
-			labels.push(ifPostType);
+		if ( ifPostType !== 'none' ) {
+			labels.push( ifPostType );
 		}
-		if (userRole.length > 0) {
-			userRole.forEach((roleValue) => {
-				const roleLabel = userRoles.find((role) => role.value === roleValue);
-				if (roleLabel) {
-					labels.push(roleLabel.label);
+		if ( userRole.length > 0 ) {
+			userRole.forEach( ( roleValue ) => {
+				const roleLabel = userRoles.find(
+					( role ) => role.value === roleValue
+				);
+				if ( roleLabel ) {
+					labels.push( roleLabel.label );
 				}
-			});
+			} );
 		}
 
-		if (customFieldName) {
-			labels.push(customFieldName);
+		if ( customFieldName ) {
+			labels.push( customFieldName );
 		}
 
-		if (periodDisplaySetting !== "none") {
-			labels.push(periodDisplaySetting);
+		if ( periodDisplaySetting !== 'none' ) {
+			labels.push( periodDisplaySetting );
 		}
 
-		let labels_string = labels.join(" / ");
+		if ( showOnlyLoginUser ) {
+			labels.push( 'showOnlyLoginUser' );
+		}
+
+		let labels_string = labels.join( ' / ' );
 
 		return (
-			<div {...useBlockProps({ className: blockClassName })}>
+			<div { ...useBlockProps( { className: blockClassName } ) }>
 				<InspectorControls>
-					<PanelBody title={__('Display Conditions', 'vk-dynamic-if-block')} className={'vkdif'}>
+					<PanelBody
+						title={ __(
+							'Display Conditions',
+							'vk-dynamic-if-block'
+						) }
+						className={ 'vkdif' }
+					>
 						<SelectControl
-							label={__('Page Type', 'vk-dynamic-if-block')}
-							value={ifPageType}
-							options={ifPageTypes}
-							onChange={(value) => setAttributes({ ifPageType: value })}
+							label={ __( 'Page Type', 'vk-dynamic-if-block' ) }
+							value={ ifPageType }
+							options={ ifPageTypes }
+							onChange={ ( value ) =>
+								setAttributes( { ifPageType: value } )
+							}
 						/>
 						<SelectControl
-							label={__('Post Type', 'vk-dynamic-if-block')}
-							value={ifPostType}
-							options={vk_dynamic_if_block_localize_data.postTypeSelectOptions}
-							onChange={(value) => setAttributes({ ifPostType: value })}
+							label={ __( 'Post Type', 'vk-dynamic-if-block' ) }
+							value={ ifPostType }
+							options={
+								vk_dynamic_if_block_localize_data.postTypeSelectOptions
+							}
+							onChange={ ( value ) =>
+								setAttributes( { ifPostType: value } )
+							}
 						/>
 						<BaseControl
 							__nextHasNoMarginBottom
 							className="dynamic-if-user-role"
-							label={__('User Role', 'vk-dynamic-if-block')}
-							help={__('If unchecked, no restrictions are imposed by user role', 'vk-dynamic-if-block')}
+							label={ __( 'User Role', 'vk-dynamic-if-block' ) }
+							help={ __(
+								'If unchecked, no restrictions are imposed by user role',
+								'vk-dynamic-if-block'
+							) }
 						>
-							{userRoles.map((role, index) => {
+							{ userRoles.map( ( role, index ) => {
 								return (
 									<CheckboxControl
 										__nextHasNoMarginBottom
-										key={index}
-										label={role.label}
-										checked={userRole.includes(role.value)}
-										onChange={(isChecked) => {
-											if (isChecked) {
-												setAttributes({ userRole: [...userRole, role.value] });
+										key={ index }
+										label={ role.label }
+										checked={ userRole.includes(
+											role.value
+										) }
+										onChange={ ( isChecked ) => {
+											if ( isChecked ) {
+												setAttributes( {
+													userRole: [
+														...userRole,
+														role.value,
+													],
+												} );
 											} else {
-												setAttributes({ userRole: userRole.filter((r) => r !== role.value) });
+												setAttributes( {
+													userRole: userRole.filter(
+														( r ) =>
+															r !== role.value
+													),
+												} );
 											}
-										}}
+										} }
 									/>
 								);
-							})}
+							} ) }
 						</BaseControl>
-						<TextControl
-							label={__('Custom Field Name', 'vk-dynamic-if-block')}
-							value={customFieldName}
-							onChange={(value) =>
-								setAttributes({ customFieldName: value })
+						<ToggleControl
+							label={ __(
+								'ログインユーザーにのみ表示',
+								'vk-dynamic-if-block'
+							) }
+							checked={ showOnlyLoginUser }
+							onChange={ ( checked ) =>
+								setAttributes( { showOnlyLoginUser: checked } )
 							}
 						/>
-						{customFieldName && (
+						<TextControl
+							label={ __(
+								'Custom Field Name',
+								'vk-dynamic-if-block'
+							) }
+							value={ customFieldName }
+							onChange={ ( value ) =>
+								setAttributes( { customFieldName: value } )
+							}
+						/>
+						{ customFieldName && (
 							<>
 								<SelectControl
-									label={__('Custom Field Rule', 'vk-dynamic-if-block')}
-									value={customFieldRule}
-									options={[
-										{ value: 'valueExists', label: __('Value Exist ( !empty() )', 'vk-dynamic-if-block') },
-										{ value: 'valueEquals', label: __('Value Equals ( === )', 'vk-dynamic-if-block') },
-									]}
-									onChange={(value) => setAttributes({ customFieldRule: value })}
+									label={ __(
+										'Custom Field Rule',
+										'vk-dynamic-if-block'
+									) }
+									value={ customFieldRule }
+									options={ [
+										{
+											value: 'valueExists',
+											label: __(
+												'Value Exist ( !empty() )',
+												'vk-dynamic-if-block'
+											),
+										},
+										{
+											value: 'valueEquals',
+											label: __(
+												'Value Equals ( === )',
+												'vk-dynamic-if-block'
+											),
+										},
+									] }
+									onChange={ ( value ) =>
+										setAttributes( {
+											customFieldRule: value,
+										} )
+									}
 								/>
-								{customFieldRule === 'valueEquals' && (
+								{ customFieldRule === 'valueEquals' && (
 									<>
 										<TextControl
-											label={__('Custom Field Value', 'vk-dynamic-if-block')}
-											value={customFieldValue}
-											onChange={(value) =>
-												setAttributes({ customFieldValue: value })
+											label={ __(
+												'Custom Field Value',
+												'vk-dynamic-if-block'
+											) }
+											value={ customFieldValue }
+											onChange={ ( value ) =>
+												setAttributes( {
+													customFieldValue: value,
+												} )
 											}
 										/>
 									</>
-								)}
+								) }
 							</>
-						)}
-						<BaseControl title={__('Display Period', 'vk-dynamic-if-block')}>
+						) }
+						<BaseControl
+							title={ __(
+								'Display Period',
+								'vk-dynamic-if-block'
+							) }
+						>
 							<SelectControl
-								label={__('Display Period Setting', 'vk-dynamic-if-block')}
-								value={periodDisplaySetting}
-								options={[
-									{ value: 'none', label: __('No restriction', 'vk-dynamic-if-block') },
-									{ value: 'deadline', label: __('Set to display deadline', 'vk-dynamic-if-block') },
-									{ value: 'startline', label: __('Set to display startline', 'vk-dynamic-if-block') },
-									{ value: 'daysSincePublic', label: __('Number of days from the date of publication', 'vk-dynamic-if-block') },
-								]}
-								onChange={(value) => setAttributes({ periodDisplaySetting: value })}
+								label={ __(
+									'Display Period Setting',
+									'vk-dynamic-if-block'
+								) }
+								value={ periodDisplaySetting }
+								options={ [
+									{
+										value: 'none',
+										label: __(
+											'No restriction',
+											'vk-dynamic-if-block'
+										),
+									},
+									{
+										value: 'deadline',
+										label: __(
+											'Set to display deadline',
+											'vk-dynamic-if-block'
+										),
+									},
+									{
+										value: 'startline',
+										label: __(
+											'Set to display startline',
+											'vk-dynamic-if-block'
+										),
+									},
+									{
+										value: 'daysSincePublic',
+										label: __(
+											'Number of days from the date of publication',
+											'vk-dynamic-if-block'
+										),
+									},
+								] }
+								onChange={ ( value ) =>
+									setAttributes( {
+										periodDisplaySetting: value,
+									} )
+								}
 								help={
 									periodDisplaySetting === 'deadline'
-										? __('After the specified date, it is hidden.', 'vk-dynamic-if-block')
+										? __(
+												'After the specified date, it is hidden.',
+												'vk-dynamic-if-block'
+										  )
 										: periodDisplaySetting === 'startline'
-											? __('After the specified date, it is display.', 'vk-dynamic-if-block')
-											: periodDisplaySetting === 'daysSincePublic'
-												? __('After the specified number of days, it is hidden.', 'vk-dynamic-if-block')
-												: __('You can set the deadline or startline to be displayed, as well as the time period.', 'vk-dynamic-if-block')
+										? __(
+												'After the specified date, it is display.',
+												'vk-dynamic-if-block'
+										  )
+										: periodDisplaySetting ===
+										  'daysSincePublic'
+										? __(
+												'After the specified number of days, it is hidden.',
+												'vk-dynamic-if-block'
+										  )
+										: __(
+												'You can set the deadline or startline to be displayed, as well as the time period.',
+												'vk-dynamic-if-block'
+										  )
 								}
 							/>
-							{periodDisplaySetting !== 'none' && (
+							{ periodDisplaySetting !== 'none' && (
 								<>
 									<SelectControl
-										label={__('Period specification method', 'vk-dynamic-if-block')}
-										value={periodSpecificationMethod}
-										options={[
-											{ value: 'direct', label: __('Direct input in this block', 'vk-dynamic-if-block') },
-											{ value: 'referCustomField', label: __('Refer to value of custom field', 'vk-dynamic-if-block') },
-										]}
-										onChange={(value) => setAttributes({ periodSpecificationMethod: value })}
+										label={ __(
+											'Period specification method',
+											'vk-dynamic-if-block'
+										) }
+										value={ periodSpecificationMethod }
+										options={ [
+											{
+												value: 'direct',
+												label: __(
+													'Direct input in this block',
+													'vk-dynamic-if-block'
+												),
+											},
+											{
+												value: 'referCustomField',
+												label: __(
+													'Refer to value of custom field',
+													'vk-dynamic-if-block'
+												),
+											},
+										] }
+										onChange={ ( value ) =>
+											setAttributes( {
+												periodSpecificationMethod:
+													value,
+											} )
+										}
 									/>
-									{periodSpecificationMethod === 'direct' && (
+									{ periodSpecificationMethod ===
+										'direct' && (
 										<NumberControl
-											label={__('Value for the specified period', 'vk-dynamic-if-block')}
-											type={periodDisplaySetting === 'daysSincePublic' ? 'number' : 'datetime-local'}
-											step={periodDisplaySetting === 'daysSincePublic' ? 1 : 60}
-											value={periodDisplayValue}
-											onChange={(value) =>
-												setAttributes({ periodDisplayValue: value })
+											label={ __(
+												'Value for the specified period',
+												'vk-dynamic-if-block'
+											) }
+											type={
+												periodDisplaySetting ===
+												'daysSincePublic'
+													? 'number'
+													: 'datetime-local'
+											}
+											step={
+												periodDisplaySetting ===
+												'daysSincePublic'
+													? 1
+													: 60
+											}
+											value={ periodDisplayValue }
+											onChange={ ( value ) =>
+												setAttributes( {
+													periodDisplayValue: value,
+												} )
 											}
 										/>
-									)}
-									{periodSpecificationMethod === 'referCustomField' && (
+									) }
+									{ periodSpecificationMethod ===
+										'referCustomField' && (
 										<>
 											<TextControl
-												label={__('Referenced custom field name', 'vk-dynamic-if-block')}
-												value={periodReferCustomField}
-												onChange={(value) =>
-													setAttributes({ periodReferCustomField: value })
+												label={ __(
+													'Referenced custom field name',
+													'vk-dynamic-if-block'
+												) }
+												value={ periodReferCustomField }
+												onChange={ ( value ) =>
+													setAttributes( {
+														periodReferCustomField:
+															value,
+													} )
 												}
 												help={
-													periodDisplaySetting === 'daysSincePublic'
-														? __('Save the value of the custom field as an integer.', 'vk-dynamic-if-block')
-														: __('Save the custom field values as Y-m-d H:i:s.', 'vk-dynamic-if-block')
+													periodDisplaySetting ===
+													'daysSincePublic'
+														? __(
+																'Save the value of the custom field as an integer.',
+																'vk-dynamic-if-block'
+														  )
+														: __(
+																'Save the custom field values as Y-m-d H:i:s.',
+																'vk-dynamic-if-block'
+														  )
 												}
 												className="vkdif__refer-cf-name"
 											/>
-											{!periodReferCustomField && (
+											{ ! periodReferCustomField && (
 												<div className="vkdif__alert vkdif__alert-warning">
-													{__('Enter the name of the custom field you wish to reference.', 'vk-dynamic-if-block')}
+													{ __(
+														'Enter the name of the custom field you wish to reference.',
+														'vk-dynamic-if-block'
+													) }
 												</div>
-											)}
+											) }
 										</>
-									)}
+									) }
 								</>
-							)}
-
+							) }
 						</BaseControl>
 						<ToggleControl
-							label={__('Exclusion designation', 'vk-dynamic-if-block')}
-							checked={exclusion}
-							onChange={(checked) => setAttributes({ exclusion: checked })}
+							label={ __(
+								'Exclusion designation',
+								'vk-dynamic-if-block'
+							) }
+							checked={ exclusion }
+							onChange={ ( checked ) =>
+								setAttributes( { exclusion: checked } )
+							}
 						/>
 					</PanelBody>
 				</InspectorControls>
-				<div className="vk-dynamic-if-block__label">{labels_string}</div>
+				<div className="vk-dynamic-if-block__label">
+					{ labels_string }
+				</div>
 
-				<InnerBlocks
-					template={MY_TEMPLATE}
-				/>
+				<InnerBlocks template={ MY_TEMPLATE } />
 			</div>
 		);
 	},
@@ -290,4 +563,4 @@ registerBlockType('vk-blocks/dynamic-if', {
 	save() {
 		return <InnerBlocks.Content />;
 	},
-});
+} );

--- a/src/index.js
+++ b/src/index.js
@@ -303,7 +303,7 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 						</BaseControl>
 						<ToggleControl
 							label={ __(
-								'ログインユーザーにのみ表示',
+								'Displayed only for logged-in users.,
 								'vk-dynamic-if-block'
 							) }
 							checked={ showOnlyLoginUser }

--- a/src/index.js
+++ b/src/index.js
@@ -303,7 +303,7 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 						</BaseControl>
 						<ToggleControl
 							label={ __(
-								'Displayed only for logged-in users.,
+								'Displayed only for logged-in users.',
 								'vk-dynamic-if-block'
 							) }
 							checked={ showOnlyLoginUser }

--- a/src/index.php
+++ b/src/index.php
@@ -27,6 +27,7 @@ function vk_dynamic_if_block_render( $attributes, $content ) {
 		'periodSpecificationMethod' => 'direct',
 		'periodDisplayValue'        => '',
 		'periodReferCustomField'    => '',
+		'showOnlyLoginUser'             => '',
 	);
 	$attributes         = array_merge( $attributes_default, $attributes );
 
@@ -280,9 +281,18 @@ function vk_dynamic_if_block_render( $attributes, $content ) {
 		}
 	}
 
+	// Login user Check //////////////////////////////////.
+
+	$display_by_login_user = true; // デフォルトで表示を許可
+
+	// ユーザーがログインしているか、またはログインユーザーのみの表示が不要な場合に表示を許可
+	if ( $attributes['showOnlyLoginUser'] && !is_user_logged_in() ) {
+		$display_by_login_user = false;
+	}
+
 	// Merge Condition Check //////////////////////////////////.
 
-	if ( $display_by_post_type && $display_by_page_type && $display_by_custom_field && $display_by_user_role && $display_by_period ) {
+	if ( $display_by_post_type && $display_by_page_type && $display_by_custom_field && $display_by_user_role && $display_by_period && $display_by_login_user ) {
 		$display = true;
 	}
 

--- a/tests/test-dynamic-if.php
+++ b/tests/test-dynamic-if.php
@@ -656,6 +656,28 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase {
 				'expected'   => '',
 			),
 			/******************************************
+			* Login User Only */
+			array(
+				'name'      => 'Only login user can view',
+				'go_to'     => get_permalink( $test_posts['parent_page_id'] ),
+				'attribute' => array(
+					'showOnlyLoginUser' => true,
+				),
+				'is_login'  => true,
+				'content'   => 'Only login user can view',
+				'expected'  => 'Only login user can view',
+			),
+			array(
+				'name'      => 'Only login user can view',
+				'go_to'     => get_permalink( $test_posts['parent_page_id'] ),
+				'attribute' => array(
+					'showOnlyLoginUser' => true,
+				),
+				'is_login'  => false,
+				'content'   => 'Only login user can view',
+				'expected'  => '',
+			),
+			/******************************************
 			 * Display Period */
 			// not specified
 			array(
@@ -987,9 +1009,14 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase {
 			if ( isset( $test['user_roles'] ) ) {
 				$test['attribute']['test_user_roles'] = $test['user_roles'];
 				$actual = vk_dynamic_if_block_render( $test['attribute'], $test['content'] );
+			} elseif ( isset( $test['is_login'] )) {
+				wp_set_current_user($test['is_login'] ? 1 : 0);
+				$actual = vk_dynamic_if_block_render( $test['attribute'], $test['content'] );
+				wp_set_current_user(0);
 			} else {
 				$actual = vk_dynamic_if_block_render( $test['attribute'], $test['content'] );
 			}
+
 
 			print 'Page : ' . esc_html( $test['name'] ) . PHP_EOL;
 			print 'go_to : ' . esc_html( $test['go_to'] ) . PHP_EOL;

--- a/tests/test-dynamic-if.php
+++ b/tests/test-dynamic-if.php
@@ -1017,7 +1017,6 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase {
 				$actual = vk_dynamic_if_block_render( $test['attribute'], $test['content'] );
 			}
 
-
 			print 'Page : ' . esc_html( $test['name'] ) . PHP_EOL;
 			print 'go_to : ' . esc_html( $test['go_to'] ) . PHP_EOL;
 			if ( isset( $test['test_meta'] ) && isset( $test['test_meta']['post_id'] ) ) {


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-dynamic-if-block/issues/47


## このプルリクで変更した事の概要

ログインユーザーにのみコンテンツを表示するオプションを追加しました。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### デザイン・UI

- [ ] 初見のユーザーが予備知識無しで使っても使いやすいようになっているか？
- [ ] 情報意味を考慮した意味グルーピング・余白になっているか？
- [ ] アラートの表示など追加した場合は他の同様の表示と同じデザインになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [x] 書けそうなテストは書いたか？

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

- 特に何も設定しない場合、表示されることを確認
- 機能をtrueにした場合、ログインしている場合にのみ表示されることを確認
- `npm run phpunit`が通ることを確認

機能追加になるので石川さん + もう一人 の確認をお願いします。

- [x] 上記記載の手順で初見の人は本当に手順が再現できるか？


## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## 実装者が確認した手順以外でレビュワーに確認して欲しい事項など



---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
