### PR TITLE
[ 仕様変更 ] カスタム投稿タイプの日付アーカイブページ（年別・月別・日別）でis_post_type_archive()がtrueを返す問題を修正 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,7 @@ However, by nesting Dynamic If Blocks, various conditional branching can be hand
 == Changelog ==
 
 [ Specification change ] Changed the UI to specify the condition branching method at the beginning
+[ Specification change ] Add the condition !is_year() && !is_month() && !is_date() for Post Type Archives.
 
 = 0.8.6 =
 [ Specification change ][ Author Archive ] Changed to target only users with the role of Contributor or higher who have at least one published article.

--- a/src/constants.js
+++ b/src/constants.js
@@ -27,7 +27,7 @@ export const PAGE_TYPE_DEFINITIONS = [
 	{
 		value: 'is_post_type_archive',
 		label: 'Post Type Archive',
-		func: 'is_post_type_archive()',
+		func: 'is_post_type_archive() && !is_year() && !is_month() && !is_date()',
 	},
 	{ value: 'is_category', label: 'Category Archive', func: 'is_category()' },
 	{ value: 'is_tag', label: 'Tag Archive', func: 'is_tag()' },

--- a/src/index.php
+++ b/src/index.php
@@ -244,7 +244,7 @@ function vk_dynamic_if_block_check_page_type($values)
         'is_page' => is_page(),
         'is_singular' => is_singular(),
         'is_home' => is_home() && !is_front_page(),
-        'is_post_type_archive' => is_post_type_archive(),
+        'is_post_type_archive' => is_post_type_archive() && !is_year() && !is_month() && !is_date(),
         'is_category' => is_category(),
         'is_tag' => is_tag(),
         'is_tax' => is_tax(),

--- a/tests/test-dynamic-if.php
+++ b/tests/test-dynamic-if.php
@@ -453,6 +453,70 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase {
 				'expected'  => 'Daily Archive page',
 			),
 			/******************************************
+			* Post Type Archive page */
+			array(
+				'name'      => 'Post Type Archive page',
+				'go_to'     => get_post_type_archive_link( 'event' ),
+				'attribute' => array(
+					'conditions' => array(
+						array(
+							'type'   => 'pageType',
+							'values' => array( 'ifPageType' => 'is_post_type_archive' ),
+						),
+					),
+				),
+				'content'   => 'Post Type Archive page',
+				'expected'  => 'Post Type Archive page',
+			),
+			/******************************************
+			* Custom Post Type Monthly Archive page (should not show with is_post_type_archive) */
+			array(
+				'name'      => 'Custom Post Type Monthly Archive page - is_post_type_archive should be false',
+				'go_to'     => get_month_link( gmdate( 'Y' ), gmdate( 'm' ) ) . '?post_type=event',
+				'attribute' => array(
+					'conditions' => array(
+						array(
+							'type'   => 'pageType',
+							'values' => array( 'ifPageType' => 'is_post_type_archive' ),
+						),
+					),
+				),
+				'content'   => 'Custom Post Type Monthly Archive page',
+				'expected'  => '',
+			),
+			/******************************************
+			* Custom Post Type Yearly Archive page (should not show with is_post_type_archive) */
+			array(
+				'name'      => 'Custom Post Type Yearly Archive page - is_post_type_archive should be false',
+				'go_to'     => get_year_link( gmdate( 'Y' ) ) . '?post_type=event',
+				'attribute' => array(
+					'conditions' => array(
+						array(
+							'type'   => 'pageType',
+							'values' => array( 'ifPageType' => 'is_post_type_archive' ),
+						),
+					),
+				),
+				'content'   => 'Custom Post Type Yearly Archive page',
+				'expected'  => '',
+			),
+			/******************************************
+			* Custom Post Type Daily Archive page (should not show with is_post_type_archive) */
+			array(
+				'name'      => 'Custom Post Type Daily Archive page - is_post_type_archive should be false',
+				'go_to'     => get_day_link( gmdate( 'Y' ), gmdate( 'm' ), gmdate( 'd' ) ) . '?post_type=event',
+				'attribute' => array(
+					'conditions' => array(
+						array(
+							'type'   => 'pageType',
+							'values' => array( 'ifPageType' => 'is_post_type_archive' ),
+						),
+					),
+				),
+				'content'   => 'Custom Post Type Daily Archive page',
+				'expected'  => '',
+			),
+			/******************************************
 			* Category archive page */
 			array(
 				'name'      => 'Category archive page',


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#77 

## このプルリクで変更した事の概要
カスタム投稿タイプの日付アーカイブページ（年別、月別、日別）で is_post_type_archive() が true を返す部分を変更しました。
src/index.php の248行目で `is_post_type_archive()` の条件に `! is_year() && ! is_month() && ! is_date()` を追加しました。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

### スクリーンショットまたは動画

#### 変更前 Before
<img width="1083" height="724" alt="スクリーンショット 2025-07-29 15 03 36" src="https://github.com/user-attachments/assets/06a1e85b-77f8-4b50-9bcc-c30ee4376674" />
<img width="1084" height="726" alt="スクリーンショット 2025-07-29 15 02 02" src="https://github.com/user-attachments/assets/13710e07-2926-4894-8565-4ddd37dc117f" />
<img width="1083" height="723" alt="スクリーンショット 2025-07-29 15 02 16" src="https://github.com/user-attachments/assets/37b847fa-bd81-474c-a63b-a160612d194e" />
<img width="1083" height="723" alt="スクリーンショット 2025-07-29 15 02 29" src="https://github.com/user-attachments/assets/cbdd226e-1734-4f90-a846-bc4d018f0b2e" />

#### 変更後 After
<img width="1083" height="724" alt="スクリーンショット 2025-07-29 15 03 36" src="https://github.com/user-attachments/assets/06a1e85b-77f8-4b50-9bcc-c30ee4376674" />
<img width="1083" height="677" alt="スクリーンショット 2025-07-29 15 00 27" src="https://github.com/user-attachments/assets/79499e78-e811-4a19-8bf0-2319b8e5f3d3" />
<img width="1083" height="664" alt="スクリーンショット 2025-07-29 15 00 42" src="https://github.com/user-attachments/assets/fdd15af8-bcee-43ab-97d7-4bdbaca16c1c" />
<img width="1083" height="667" alt="スクリーンショット 2025-07-29 15 01 00" src="https://github.com/user-attachments/assets/2525cd68-8425-4bd3-bc5c-b39cf29b7afb" />

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### デザイン・UI

- [ ] 初見のユーザーが予備知識無しで使っても使いやすいようになっているか？ → スキップ
- [ ] 情報意味を考慮した意味グルーピング・余白になっているか？ → スキップ
- [ ] アラートの表示など追加した場合は他の同様の表示と同じデザインになっているか？ → スキップ

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [x] 書けそうなテストは書いたか？

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

1. X-T9にして 外観 > エディター > テンプレート > インデックス に移動
2. Dynamic Ifブロックを設置して以下の条件を選択
   - ページタイプ: 投稿タイプアーカイブ
   - 投稿タイプ: カスタム投稿タイプを指定
3. Dynamic Ifブロックの中に適当なブロックを入れて保存
4. カスタム投稿タイプの月別アーカイブページ（例：**/2023/05/?post_type=works**）にアクセスして、Dynamic Ifブロックの内容が表示されないことを確認
5. 年別アーカイブページ（例：**/2023/?post_type=works**）でも同様に表示されないことを確認
6. 日別アーカイブページ（例：**/2023/05/15/?post_type=works**）でも同様に表示されないことを確認
7. 通常のカスタム投稿タイプアーカイブページ（例：**/works**）では正常に表示されることを確認

- [x] 上記記載の手順で初見の人は本当に手順が再現できるか？


## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？ → スキップ

## 実装者が確認した手順以外でレビュワーに確認して欲しい事項など

実装者と同じ確認を行ってください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
