### PR TITLE
[ 不具合修正 ] 条件分岐のラベルが翻訳されない不具合を修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -35,7 +35,8 @@ However, by nesting Dynamic If Blocks, various conditional branching can be hand
 
 == Changelog ==
 
-[ Bug fix ] Fix LAnguage condition error
+[ Bug fix ] Fix an issue where the condition label is not translated.
+[ Bug fix ] Fix Language condition error
 
 = 1.3.1 =
 [ Bug fix ] Fix translation not working for some labels.

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,17 +1,17 @@
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 // 条件タイプの定義
 export const CONDITION_TYPE_LABELS = {
-	pageType: __( 'Page Type', 'vk-dynamic-if-block' ),
-	postType: __( 'Post Type', 'vk-dynamic-if-block' ),
-	taxonomy: __( 'Taxonomy', 'vk-dynamic-if-block' ),
-	language: __( 'Language', 'vk-dynamic-if-block' ),
-	userRole: __( 'User Role', 'vk-dynamic-if-block' ),
-	postAuthor: __( 'Post Author', 'vk-dynamic-if-block' ),
-	customField: __( 'Custom Field', 'vk-dynamic-if-block' ),
-	period: __( 'Display Period', 'vk-dynamic-if-block' ),
-	loginUser: __( 'Login User Only', 'vk-dynamic-if-block' ),
-	mobileDevice: __( 'Mobile Device Only', 'vk-dynamic-if-block' ),
+	pageType: _x( 'Page Type', 'Condition Type Label', 'vk-dynamic-if-block' ),
+	postType: _x( 'Post Type', 'Condition Type Label', 'vk-dynamic-if-block' ),
+	taxonomy: _x( 'Taxonomy', 'Condition Type Label', 'vk-dynamic-if-block' ),
+	language: _x( 'Language', 'Condition Type Label', 'vk-dynamic-if-block' ),
+	userRole: _x( 'User Role', 'Condition Type Label', 'vk-dynamic-if-block' ),
+	postAuthor: _x( 'Post Author', 'Condition Type Label', 'vk-dynamic-if-block' ),
+	customField: _x( 'Custom Field', 'Condition Type Label', 'vk-dynamic-if-block' ),
+	period: _x( 'Display Period', 'Condition Type Label', 'vk-dynamic-if-block' ),
+	loginUser: _x( 'Login User Only', 'Condition Type Label', 'vk-dynamic-if-block' ),
+	mobileDevice: _x( 'Mobile Device Only', 'Condition Type Label', 'vk-dynamic-if-block' ),
 };
 
 // ページタイプ定義


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

<img width="286" height="519" alt="スクリーンショット 2025-08-28 11 10 30" src="https://github.com/user-attachments/assets/0cd92f08-367d-4b71-b87b-612ac6373e4e" />

## このプルリクで変更した事の概要

_x でコンテキスト追加

※ .org で翻訳追加するまでは翻訳はあたらなくなる