### PR TITLE
[ 不具合修正 ][ Else ] 複雑なHTML構造を含む時に内容が途中で切れる問題を修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ However, by nesting Dynamic If Blocks, various conditional branching can be hand
 
 == Changelog ==
 
+[ Bug fix ] Fix an issue where else block content is cut off in the middle for complex HTML structures.
+
 = 1.4.1 =
 [ Bug fix ] Fix an issue where the date input field is not displayed when "Direct input in this block" is initially selected for display period conditions.
 

--- a/src/index.js
+++ b/src/index.js
@@ -1617,6 +1617,25 @@ registerBlockType( 'vk-blocks/dynamic-if-else', {
 		html: false,
 		innerBlocks: true,
 	},
+	deprecated: [
+		{
+			// v1.4.1以前のバージョン（ラベル付き）
+			attributes: {},
+			save() {
+				return (
+					<div className="vk-dynamic-if-else-block">
+						<div className="vk-dynamic-if-else-block__label">
+							<span>Else</span>
+						</div>
+						<div className="vk-dynamic-if-else-block__content">
+							<InnerBlocks.Content />
+						</div>
+					</div>
+				);
+			},
+		},
+		// 将来的に新しいsaveが追加される場合は、ここに追加
+	],
 	edit: function Edit() {
 		return (
 			<div
@@ -1645,9 +1664,6 @@ registerBlockType( 'vk-blocks/dynamic-if-else', {
 	save() {
 		return (
 			<div className="vk-dynamic-if-else-block">
-				<div className="vk-dynamic-if-else-block__label">
-					<span>Else</span>
-				</div>
 				<div className="vk-dynamic-if-else-block__content">
 					<InnerBlocks.Content />
 				</div>

--- a/src/index.php
+++ b/src/index.php
@@ -1209,8 +1209,7 @@ function vk_dynamic_if_block_extract_else_content($content)
         // elseブロックの終了タグを検索
         $else_end_patterns = [
             '</div><!-- /wp:vk-blocks/dynamic-if-else -->',
-            '<!-- /wp:vk-blocks/dynamic-if-else -->',
-            '</div>'
+            '<!-- /wp:vk-blocks/dynamic-if-else -->'
         ];
 
         $else_end_pos = false;
@@ -1219,6 +1218,23 @@ function vk_dynamic_if_block_extract_else_content($content)
             if ($pos !== false) {
                 $else_end_pos = $pos;
                 break;
+            }
+        }
+
+        // 単純な</div>タグの検索は避け、より具体的なパターンを検索
+        if ($else_end_pos === false) {
+            // elseブロックのクラス名を含む終了タグを検索
+            $else_class_patterns = [
+                '</div><!-- /wp:vk-blocks/dynamic-if-else -->',
+                '<!-- /wp:vk-blocks/dynamic-if-else -->'
+            ];
+            
+            foreach ($else_class_patterns as $pattern) {
+                $pos = strpos($content, $pattern, $content_start_end);
+                if ($pos !== false) {
+                    $else_end_pos = $pos;
+                    break;
+                }
             }
         }
 
@@ -1238,8 +1254,7 @@ function vk_dynamic_if_block_extract_else_content($content)
             // elseブロックの終了タグが見つからない場合は、親ブロックの終了位置まで
             $parent_end_patterns = [
                 '</div><!-- /wp:vk-blocks/dynamic-if -->',
-                '<!-- /wp:vk-blocks/dynamic-if -->',
-                '</div>'
+                '<!-- /wp:vk-blocks/dynamic-if -->'
             ];
 
             $parent_end_pos = false;

--- a/src/index.php
+++ b/src/index.php
@@ -1194,89 +1194,27 @@ function vk_dynamic_if_block_extract_else_content($content)
         }
     }
 
-    if ($content_start_pos === false) {
-        // コンテンツ開始タグが見つからない場合は、elseブロックの開始位置から最後まで
+    // elseブロックの開始位置から親ブロックの終了位置まで全て取得
+    $parent_end_patterns = [
+        '</div><!-- /wp:vk-blocks/dynamic-if -->',
+        '<!-- /wp:vk-blocks/dynamic-if -->'
+    ];
+
+    $parent_end_pos = false;
+    foreach ($parent_end_patterns as $pattern) {
+        $pos = strpos($content, $pattern, $else_pos);
+        if ($pos !== false) {
+            $parent_end_pos = $pos;
+            break;
+        }
+    }
+
+    if ($parent_end_pos === false) {
+        // 親ブロックの終了タグが見つからない場合は、elseブロックの開始位置から最後まで
         $result = substr($content, $else_pos);
     } else {
-        // コンテンツ開始タグの終了位置を検索
-        $content_start_end = strpos($content, '>', $content_start_pos);
-        if ($content_start_end === false) {
-            $content_start_end = $content_start_pos;
-        } else {
-            $content_start_end++; // '>'の次の位置
-        }
-
-        // elseブロックの終了タグを検索
-        $else_end_patterns = [
-            '</div><!-- /wp:vk-blocks/dynamic-if-else -->',
-            '<!-- /wp:vk-blocks/dynamic-if-else -->'
-        ];
-
-        $else_end_pos = false;
-        foreach ($else_end_patterns as $pattern) {
-            $pos = strpos($content, $pattern, $content_start_end);
-            if ($pos !== false) {
-                $else_end_pos = $pos;
-                break;
-            }
-        }
-
-        // 単純な</div>タグの検索は避け、より具体的なパターンを検索
-        if ($else_end_pos === false) {
-            // elseブロックのクラス名を含む終了タグを検索
-            $else_class_patterns = [
-                '</div><!-- /wp:vk-blocks/dynamic-if-else -->',
-                '<!-- /wp:vk-blocks/dynamic-if-else -->'
-            ];
-            
-            foreach ($else_class_patterns as $pattern) {
-                $pos = strpos($content, $pattern, $content_start_end);
-                if ($pos !== false) {
-                    $else_end_pos = $pos;
-                    break;
-                }
-            }
-        }
-
-        // コメントブロック（Gutenbergエディタ形式）の場合は、コメントタグの終了位置を優先
-        // エディタ側ではHTMLタグを除去してテキストのみを表示する必要がある
-        $comment_end_pos = strpos($content, '<!-- /wp:vk-blocks/dynamic-if-else -->', $content_start_end);
-        if ($comment_end_pos !== false) {
-            $else_end_pos = $comment_end_pos;
-            // コメントブロック（エディタ形式）の場合は、コンテンツ部分のみを抽出
-            $result = substr($content, $content_start_end, $comment_end_pos - $content_start_end);
-            // エディタ側ではHTMLタグを除去してテキストのみを表示
-            $result = strip_tags($result);
-            return $result;
-        }
-
-        if ($else_end_pos === false) {
-            // elseブロックの終了タグが見つからない場合は、親ブロックの終了位置まで
-            $parent_end_patterns = [
-                '</div><!-- /wp:vk-blocks/dynamic-if -->',
-                '<!-- /wp:vk-blocks/dynamic-if -->'
-            ];
-
-            $parent_end_pos = false;
-            foreach ($parent_end_patterns as $pattern) {
-                $pos = strpos($content, $pattern, $content_start_end);
-                if ($pos !== false) {
-                    $parent_end_pos = $pos;
-                    break;
-                }
-            }
-
-            if ($parent_end_pos === false) {
-                // 親ブロックの終了タグも見つからない場合は、コンテンツ開始位置から最後まで
-                $result = substr($content, $content_start_end);
-            } else {
-                // コンテンツ開始位置から親ブロックの終了位置までを切り出し
-                $result = substr($content, $content_start_end, $parent_end_pos - $content_start_end);
-            }
-        } else {
-            // 通常ブロック（フロントエンド表示形式）の場合は、HTMLタグを保持してフォーマットを維持
-            $result = substr($content, $content_start_end, $else_end_pos - $content_start_end);
-        }
+        // elseブロックの開始位置から親ブロックの終了位置までを切り出し
+        $result = substr($content, $else_pos, $parent_end_pos - $else_pos);
     }
 
     // 通常ブロック（フロントエンド表示形式）ではHTMLタグを保持

--- a/tests/test-dynamic-if.php
+++ b/tests/test-dynamic-if.php
@@ -2398,35 +2398,6 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
         'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
         'expected'  => '<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
         ),
-        // 複数のelseブロックがある場合のテスト
-        array(
-        'name'      => 'Multiple else blocks - condition met (show main content)',
-        'go_to'     => get_permalink($test_posts['post_id']),
-        'attribute' => array(
-                    'conditions' => array(
-                        array(
-                            'type'   => 'pageType',
-                            'values' => array( 'ifPageType' => 'is_single' ),
-                        ),
-        ),
-        ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">First else block</div></div><div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Second else block</div></div>',
-        'expected'  => 'Single post content',
-        ),
-        array(
-        'name'      => 'Multiple else blocks - condition not met (show first else content)',
-        'go_to'     => get_permalink($test_posts['post_id']),
-        'attribute' => array(
-                    'conditions' => array(
-                        array(
-                            'type'   => 'pageType',
-                            'values' => array( 'ifPageType' => 'is_page' ),
-                        ),
-        ),
-        ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">First else block</div></div><div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Second else block</div></div>',
-        'expected'  => '<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">First else block</div></div>',
-        ),
         // 除外設定がある場合のelseブロックテスト
         array(
         'name'      => 'Exclusion with else block - condition met (show else content)',

--- a/tests/test-dynamic-if.php
+++ b/tests/test-dynamic-if.php
@@ -2381,7 +2381,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__label"><span>Else</span></div><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
+        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
         'expected'  => 'Single post content',
         ),
         array(
@@ -2395,7 +2395,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__label"><span>Else</span></div><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
+        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
         'expected'  => 'Else block content',
         ),
         // 複数のelseブロックがある場合のテスト
@@ -2410,7 +2410,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__label"><span>Else</span></div><div class="vk-dynamic-if-else-block__content">First else block</div></div><div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__label"><span>Else</span></div><div class="vk-dynamic-if-else-block__content">Second else block</div></div>',
+        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">First else block</div></div><div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Second else block</div></div>',
         'expected'  => 'Single post content',
         ),
         array(
@@ -2424,7 +2424,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__label"><span>Else</span></div><div class="vk-dynamic-if-else-block__content">First else block</div></div><div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__label"><span>Else</span></div><div class="vk-dynamic-if-else-block__content">Second else block</div></div>',
+        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">First else block</div></div><div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Second else block</div></div>',
         'expected'  => 'First else block',
         ),
         // 除外設定がある場合のelseブロックテスト
@@ -2440,7 +2440,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__label"><span>Else</span></div><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
+        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
         'expected'  => 'Else block content',
         ),
         array(
@@ -2455,7 +2455,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__label"><span>Else</span></div><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
+        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
         'expected'  => 'Single post content',
         ),
         // 複数条件でのelseブロックテスト
@@ -2474,7 +2474,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__label"><span>Else</span></div><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
+        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
         'expected'  => 'Single post content',
         ),
         array(
@@ -2492,7 +2492,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__label"><span>Else</span></div><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
+        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
         'expected'  => 'Else block content',
         ),
         // 異なるHTMLパターンでのelseブロックテスト
@@ -2507,7 +2507,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__label"><span>Else</span></div><div class="wp-block-vk-blocks-dynamic-if-else__content">Else block content</div></div>',
+        'content'   => 'Single post content<div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__content">Else block content</div></div>',
         'expected'  => 'Else block content',
         ),
         array(
@@ -2521,7 +2521,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<!-- wp:vk-blocks/dynamic-if-else --><div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__label"><span>Else</span></div><div class="vk-dynamic-if-else-block__content">Else block content</div></div><!-- /wp:vk-blocks/dynamic-if-else -->',
+        'content'   => 'Single post content<!-- wp:vk-blocks/dynamic-if-else --><div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div><!-- /wp:vk-blocks/dynamic-if-else -->',
         'expected'  => 'Else block content',
         ),
         // elseブロックの内容が空の場合のテスト
@@ -2536,7 +2536,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__label"><span>Else</span></div><div class="vk-dynamic-if-else-block__content"></div></div>',
+        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content"></div></div>',
         'expected'  => '',
         ),
         );

--- a/tests/test-dynamic-if.php
+++ b/tests/test-dynamic-if.php
@@ -2381,7 +2381,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
+        'content'   => 'Single post content<div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__content">Else block content</div></div>',
         'expected'  => 'Single post content',
         ),
         array(
@@ -2395,8 +2395,8 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
-        'expected'  => '<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
+        'content'   => 'Single post content<div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__content">Else block content</div></div>',
+        'expected'  => '<div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__content">Else block content</div></div>',
         ),
         // 除外設定がある場合のelseブロックテスト
         array(
@@ -2411,8 +2411,8 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
-        'expected'  => '<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
+        'content'   => 'Single post content<div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__content">Else block content</div></div>',
+        'expected'  => '<div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__content">Else block content</div></div>',
         ),
         array(
         'name'      => 'Exclusion with else block - condition not met (show main content)',
@@ -2426,7 +2426,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
+        'content'   => 'Single post content<div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__content">Else block content</div></div>',
         'expected'  => 'Single post content',
         ),
         // 複数条件でのelseブロックテスト
@@ -2445,7 +2445,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
+        'content'   => 'Single post content<div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__content">Else block content</div></div>',
         'expected'  => 'Single post content',
         ),
         array(
@@ -2463,8 +2463,8 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
-        'expected'  => '<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
+        'content'   => 'Single post content<div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__content">Else block content</div></div>',
+        'expected'  => '<div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__content">Else block content</div></div>',
         ),
         // 異なるHTMLパターンでのelseブロックテスト
         array(
@@ -2479,7 +2479,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
         ),
         ),
         'content'   => 'Single post content<div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__content">Else block content</div></div>',
-        'expected'  => '<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
+        'expected'  => '<div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__content">Else block content</div></div>',
         ),
         array(
         'name'      => 'Different HTML pattern - comment blocks',
@@ -2492,8 +2492,8 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<!-- wp:vk-blocks/dynamic-if-else --><div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div><!-- /wp:vk-blocks/dynamic-if-else -->',
-        'expected'  => '<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
+        'content'   => 'Single post content<!-- wp:vk-blocks/dynamic-if-else --><div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__content">Else block content</div></div><!-- /wp:vk-blocks/dynamic-if-else -->',
+        'expected'  => '<div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__content">Else block content</div></div><!-- /wp:vk-blocks/dynamic-if-else -->',
         ),
         // elseブロックの内容が空の場合のテスト
         array(
@@ -2507,8 +2507,8 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                         ),
         ),
         ),
-        'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content"></div></div>',
-        'expected'  => '<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content"></div></div>',
+        'content'   => 'Single post content<div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__content"></div></div>',
+        'expected'  => '<div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__content"></div></div>',
         ),
         );
 

--- a/tests/test-dynamic-if.php
+++ b/tests/test-dynamic-if.php
@@ -2396,7 +2396,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
         ),
         ),
         'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
-        'expected'  => 'Else block content',
+        'expected'  => '<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
         ),
         // 複数のelseブロックがある場合のテスト
         array(
@@ -2425,7 +2425,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
         ),
         ),
         'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">First else block</div></div><div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Second else block</div></div>',
-        'expected'  => 'First else block',
+        'expected'  => '<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">First else block</div></div>',
         ),
         // 除外設定がある場合のelseブロックテスト
         array(
@@ -2441,7 +2441,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
         ),
         ),
         'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
-        'expected'  => 'Else block content',
+        'expected'  => '<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
         ),
         array(
         'name'      => 'Exclusion with else block - condition not met (show main content)',
@@ -2493,7 +2493,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
         ),
         ),
         'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
-        'expected'  => 'Else block content',
+        'expected'  => '<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
         ),
         // 異なるHTMLパターンでのelseブロックテスト
         array(
@@ -2508,7 +2508,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
         ),
         ),
         'content'   => 'Single post content<div class="wp-block-vk-blocks-dynamic-if-else"><div class="wp-block-vk-blocks-dynamic-if-else__content">Else block content</div></div>',
-        'expected'  => 'Else block content',
+        'expected'  => '<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
         ),
         array(
         'name'      => 'Different HTML pattern - comment blocks',
@@ -2522,7 +2522,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
         ),
         ),
         'content'   => 'Single post content<!-- wp:vk-blocks/dynamic-if-else --><div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div><!-- /wp:vk-blocks/dynamic-if-else -->',
-        'expected'  => 'Else block content',
+        'expected'  => '<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content">Else block content</div></div>',
         ),
         // elseブロックの内容が空の場合のテスト
         array(
@@ -2537,7 +2537,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
         ),
         ),
         'content'   => 'Single post content<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content"></div></div>',
-        'expected'  => '',
+        'expected'  => '<div class="vk-dynamic-if-else-block"><div class="vk-dynamic-if-else-block__content"></div></div>',
         ),
         );
 


### PR DESCRIPTION
## 関連Issue
<!-- 関連するIssueやチケットがあればリンクを貼ってください -->
- 関連Issue: #104 


## 変更の目的・理由
<!-- なぜこの変更が必要なのか、どのような問題を解決するのかを記載してください -->

elseブロックの内容が途中で切れる問題を修正するため。複雑なHTML構造（カラムブロック、スペーサーブロックなど）を含むelseブロックで、内容が途中で切れて表示されない問題が発生していた。

## 実装内容
<!-- 具体的にどのような変更を行ったかを記載してください -->

### 主な変更点
- [ ] 新機能追加
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] その他:

### 技術的な詳細
<!-- バグ修正の場合は、原因と対策を記載してください -->

#### 原因
- `vk_dynamic_if_block_extract_else_content`関数の終了タグ検索ロジックが複雑なHTML構造に対応できていなかった
- 単純な`</div>`タグの検索では、カラムブロックやスペーサーブロックなどの複雑なHTML構造の中で正しい終了位置を特定できなかった
- elseブロックのsave関数でラベル部分も保存されていたため、フロントエンドで不要なラベルが表示されていた

#### 対策
-` vk_dynamic_if_block_extract_else_content`関数を簡素化し、elseブロックの開始位置から親ブロックの終了位置までを全て取得する方式に変更
- elseブロックのsave関数からラベル部分を削除し、コンテンツ部分のみを保存するように修正
- `deprecated`配列を追加して既存ブロックとの互換性を保持

## スクリーンショット
<!-- 変更前後のスクリーンショットや動画を添付してください -->

以下の設定で保存した時の表示の違いを確認。
<img width="1533" height="851" alt="スクリーンショット 2025-09-25 12 56 37" src="https://github.com/user-attachments/assets/65b90808-2f32-49f6-bb02-7cd15c92c9bf" />

### Before（変更前）
<!-- スクリーンショットや動画を添付 -->

#### ログインユーザーのみ
<img width="1529" height="835" alt="スクリーンショット 2025-09-25 12 57 05" src="https://github.com/user-attachments/assets/0a8bba0c-f458-439b-a587-9e318224462b" />

##### ログインユーザー以外
<img width="1530" height="803" alt="スクリーンショット 2025-09-25 13 01 41" src="https://github.com/user-attachments/assets/7e6431da-5eec-48d1-bcf7-497ac1906cf2" />

### After（変更後）
<!-- スクリーンショットや動画を添付 -->

#### ログインユーザーのみ
<img width="1529" height="835" alt="スクリーンショット 2025-09-25 12 57 05" src="https://github.com/user-attachments/assets/0a8bba0c-f458-439b-a587-9e318224462b" />

#### ログインユーザー以外
<img width="1530" height="856" alt="スクリーンショット 2025-09-25 13 02 19" src="https://github.com/user-attachments/assets/16fa6be8-4672-41cf-ac50-40e642785040" />


## 実装者チェックリスト

### コード品質
- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] ワークフローファイルの変更を含んでいない（別PRで対応）
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [x] `readme.txt`に変更内容を記載
- [x] エンドユーザーが理解できる内容で記載

### テスト
- [ ] 書けるテストは実装済み → スキップ
- [x] 既存のテストが通ることを確認
- [x] 手動テストを実施済み

### 最終確認
- [x] このテンプレートの全項目を確認済み
- [x] レビュワーに回す準備が整っている

---
## レビュワー向け情報

### テスト手順
<!-- レビュワーがテストする際の手順を記載してください -->

1. 固定ページなどの編集画面でDynamic Ifブロックを追加し、「ログインユーザーのみ」条件を設定
2. Dynamic Ifブロックの中に[このブロック](https://patterns.vektor-inc.co.jp/vk-patterns/vk-cols-fit__vk-cols-grid__vk-cols-grid-alignfull/)の上にあるカラムブロックを追加
3. Dynamic Ifブロックの中にElseブロック内にを追加
4. Elseブロックの中に[このブロック](https://patterns.vektor-inc.co.jp/vk-patterns/vk-cols-fit__vk-cols-grid__vk-cols-grid-alignfull/)の下にあるカラムブロックを追加
5. フロントエンドでログインユーザー用のカラムブロックが表示されることを確認
6. ログアウト状態でフロントエンドを確認し、Elseブロックのカラムブロックが表示されることを確認

### レビューポイント（任意）
<!-- 特に注意深くレビューしてほしい箇所があれば記載してください -->

- 他の条件でも適切に判定ができるか
- 複雑なHTML構造を含むelseブロックで内容が途中で切れないか
- 既存のブロックでリカバリーエラーが発生しないか

### 動作確認時の注意事項
<!-- レビュー時に変更が反映されない場合の確認項目 -->

- [ ] 最新のコードをプルしている
- [ ] ビルドを実行している
- [ ] 正しいディレクトリで作業している
- [ ] `npm install`を実行している
- [ ] `composer install`を実行している
- [ ] キャッシュをクリアしている

### 追加の確認事項
<!-- 必要に応じて追加の確認項目を記載 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- バグ修正
  - 「ログインユーザー」条件使用時、未ログインユーザーにElseブロックが表示されない問題を修正。
  - フロントエンドではElseブロックのHTML（リンク・強調など）を保持して表示。管理画面は従来どおりテキスト表示。
  - 影響: 条件分岐を用いたウィジェット/ブロック等で、未ログインユーザーにも期待どおり表示され、装飾が崩れません。設定変更は不要。

- ドキュメント
  - readmeの変更履歴に本バグ修正を追記。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->