### PR TITLE
[ その他 ][ 7.0 対応 ] WordPress 7.0 でパターンから挿入したブロックが編集できなくなる問題への対応

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -35,7 +35,7 @@ However, by nesting Dynamic If Blocks, various conditional branching can be hand
 
 == Changelog ==
 
-[ Other ] WordPress 7.0 のパターン挿入時にブロックがロックされて編集できなくなる問題に対応。supports.contentRole を追加してパターン内で選択・操作可能にしました。
+[ Other ] WordPress 7.0 のパターン挿入時にブロックがロックされて編集できなくなる問題に対応。
 [ Other ] Update vk-helpers library from 0.0.4 to 0.2.1.
 
 = 1.6.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,7 @@ However, by nesting Dynamic If Blocks, various conditional branching can be hand
 
 == Changelog ==
 
+[ Other ] WordPress 7.0 のパターン挿入時にブロックがロックされて編集できなくなる問題に対応。supports.contentRole を追加してパターン内で選択・操作可能にしました。
 [ Other ] Update vk-helpers library from 0.0.4 to 0.2.1.
 
 = 1.6.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -35,7 +35,7 @@ However, by nesting Dynamic If Blocks, various conditional branching can be hand
 
 == Changelog ==
 
-[ Other ] WordPress 7.0 のパターン挿入時にブロックがロックされて編集できなくなる問題に対応。
+[ Other ] Fix an issue where blocks become locked and cannot be edited when inserting patterns in WordPress 7.0.
 [ Other ] Update vk-helpers library from 0.0.4 to 0.2.1.
 
 = 1.6.0 =

--- a/src/block.json
+++ b/src/block.json
@@ -99,6 +99,7 @@
 		}
 	},
 	"supports": {
+		"contentRole": true,
 		"html": false,
 		"innerBlocks": true
 	},

--- a/src/index.js
+++ b/src/index.js
@@ -115,6 +115,7 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 		},
 	},
 	supports: {
+		contentRole: true,
 		html: false,
 		innerBlocks: true,
 	},
@@ -1783,6 +1784,7 @@ registerBlockType( 'vk-blocks/dynamic-if-else', {
 	parent: [ 'vk-blocks/dynamic-if' ],
 	attributes: {},
 	supports: {
+		contentRole: true,
 		html: false,
 		innerBlocks: true,
 	},


### PR DESCRIPTION
## 概要

WordPress 7.0では、パターンから挿入したブロックが自動的にロック（編集不可）になる新しい仕様（contentOnlyモード/コンテンツのみ編集モード）が入ります。このままだと本プラグインが提供する「条件分岐ブロック」（Dynamic If / Dynamic If Else）もロックされ、ユーザーがパターンを挿入したときに中の条件分岐そのものを選択・操作できなくなるため、ブロック全体を「コンテンツ編集可能」とマークするフラグ（`supports.contentRole: true`）を追加します。

## 変更内容

- ブロック定義ファイル（`src/block.json`）のsupportsに `contentRole: true` を追加
- ブロック登録JavaScript（`src/index.js`）の `registerBlockType` 呼び出し（Dynamic IfとDynamic If Elseの2箇所）のsupportsにも同じ `contentRole: true` を追加

条件設定（表示するページ種別 `ifPageType`、ユーザー権限 `userRole` 等）は「構造的な設定」であってユーザーが触る「コンテンツ」ではないため、属性単位の `role: "content"` は付けていません。ブロック内に配置された子ブロック（InnerBlocks）は、それぞれの子ブロック自身が持つ `role: "content"` 宣言に従って編集可能になります。

## 実装者の検証済み内容

WP 7.0-RC2のローカル環境で、グループブロック（`Group`）配下にパターン識別子（`metadata.patternName`）を設定して条件分岐ブロックを配置し、「コンテンツのみ編集モード」（`editingMode=contentOnly`）に切り替わることをPlaywrightで確認済み：

```
core/group mode=default（グループ：通常編集モード）
  vk-blocks/dynamic-if mode=contentOnly ✅（条件分岐ブロック：コンテンツのみ編集モード）
    core/paragraph mode=contentOnly ✅（中の段落ブロック：同上）
```

### 実機検証結果（VK Pattern Library のパターン挿入）

VK Pattern Library のパターン「カスタムフィールド表示用 カラムブロックテーブル（小）」（Dynamic If を2つ含む）を WP 7.0-RC2 で挿入し、`wp.data.select('core/block-editor').getBlockEditingMode()` で各ブロックの editingMode を取得した結果：

| 状態 | vk-blocks/dynamic-if の editingMode |
|---|---|
| **Before**（main = `supports.contentRole` 未付与） | `disabled` ❌（Dynamic If 自身がロック・コンテンツツリーにも表示されない） |
| **After**（本PR = `supports.contentRole: true` 付与） | `contentOnly` ✅（Dynamic If を選択可、中の core/cover・core/paragraph も編集可能） |

## スクリーンショット

VK Pattern Library のパターン「カスタムフィールド表示用 カラムブロックテーブル（小）」を WordPress 7.0-RC2 の投稿エディタで挿入した状態の比較です。

### Before（変更前 / main）

Dynamic If が `editingMode=disabled` のため、コンテンツツリーから Dynamic If が消え、子の `core/cover` / `core/paragraph` のみが表示される（Dynamic If 自身は選択・操作できない）。

![before](https://github.com/vektor-inc/review-assets/blob/main/vk-dynamic-if-block/pr-129/before-pattern-content-only.png?raw=true)

### After（変更後 / feature/content-role）

Dynamic If が `editingMode=contentOnly` となり、コンテンツツリーに表示されてクリック選択可能になる。中の子ブロック（`core/cover` / `core/paragraph`）も contentOnly モードで編集可能になる。

![after](https://github.com/vektor-inc/review-assets/blob/main/vk-dynamic-if-block/pr-129/after-pattern-content-only.png?raw=true)

## レビュー担当者に実施いただきたいテスト

### 1. パターン経由での編集確認（本Issue対象）

**前提**:

- 検証環境: WordPress 7.0-RC2 以降
- テーマ: **X-T9**（VK Pattern Library 連携の動作確認に使う）
- 有効化プラグイン: **vk-block-patterns**（パターンライブラリ機能の取り込みに必要）／ vk-dynamic-if-block（本PR の対象）
- VWS ログインを設定済みの環境で、対象パターンをお気に入り登録するor現在のテーマ該当カテゴリに含まれる状態にする

**対象パターン例**: 「カスタムフィールド表示用 カラムブロックテーブル（小）」（Dynamic If を2つ含む。VK Pattern Library 内で検索）／ <https://patterns.vektor-inc.co.jp/vk-patterns/header-hero-slider/>（その他 Dynamic If を含むパターン）

**手順（Dynamic If）**:
- [ ] WP 7.0-RC環境でエディターを開く
- [ ] [+] → パターン → 「VK Pattern Library - Favorites」または「VK Pattern Library -（テーマ名）」から対象パターンを挿入
- [ ] 挿入後、Dynamic Ifブロックがクリックで選択できること
- [ ] 中の子ブロック（段落や画像など）がそれぞれの `role: "content"` 宣言に従って編集できること
- [ ] 保存後にフロント表示で差異がないこと

**手順（Dynamic If Else・条件切替での両側確認）**:
- [ ] Dynamic If Elseブロックを含むパターン、または手動挿入で配置
- [ ] 条件TRUE側の子ブロックが、コンテンツのみ編集モード下でクリック選択・編集できること
- [ ] 条件FALSE側（else側）の子ブロックが、同様に選択・編集できること
- [ ] 条件を切り替えた後（プレビューorフロント）、各分岐の編集内容が正しく出力されること

### 2. WP 6.9（現行正式版）での互換性確認

- [ ] WP 6.9環境でDynamic If / Dynamic If Elseを含む投稿を **挿入 → 保存 → 再編集** の3ステップで実機確認
- [ ] 挿入・保存・再編集のいずれの段階でもエラーや警告が出ないこと（`contentRole` は6.9では未知のキーとして黙殺される想定）
- [ ] ブロックエディターのコンソールに `contentRole` 関連の警告が出ないこと
- [ ] 既存コンテンツの表示・編集・保存に差異がないこと

### 3. 自動テスト

- [ ] CIのPHPUnitが通過していること
- [ ] CIのE2Eテストが通過していること

### 4. ビジュアル回帰

- [ ] エディター画面・フロント画面のBefore/Afterスクリーンショットで表示差異がないこと

## 副作用

なし想定（通常編集・保存HTML出力・旧WP互換性いずれも影響なし）。上記テストで最終確認します。

## 実装者チェックリスト

- [x] 変更ファイルの内容を目視で確認した
- [x] readme.txtの変更履歴（Changelog）に追記した
- [x] 書けるテストは書いた（Playwrightで実機検証）
- [x] 既存のテストが通ることを確認

## 関連

- 親Issue: vektor-inc/multi-repo-tasks#10
- 子Issue: #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * WordPress 7.0でパターン経由で挿入されたブロックがロック状態になる問題を修正し、選択と編集が可能に

* **Other**
  * 一部ブロックにコンテンツロールのサポートを追加し、編集・操作性と互換性を向上
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

