### PR TITLE
[ 開発環境 ] PHPUnit テストをリリース時と run-ci ラベル付き PR のみ実行に変更

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,10 @@ on:
     pull_request:
         branches:
             - main
+        types: [opened, reopened, labeled, synchronize]
 jobs:
     php_unit:
+        if: contains(github.event.pull_request.labels.*.name, 'run-ci')
         name: php unit test
         runs-on: ubuntu-latest
         strategy:


### PR DESCRIPTION
## 概要
GitHub Actions の消費削減のため、PHPUnit テストの実行を `run-ci` ラベル付き PR のときのみに制限します。

## 変更内容
- `.github/workflows/test.yml`
  - `on.pull_request.types` に `[opened, reopened, labeled, synchronize]` を追加
  - `php_unit` ジョブに `if: contains(github.event.pull_request.labels.*.name, 'run-ci')` を追加
  - （元々 push トリガーは無し）
## 確認手順
1. ラベル無しの PR ではワークフロー（テストジョブ）が起動しないこと
2. `run-ci` ラベルを付与すると起動すること
3. push（ブランチへの直接 push）では起動しないこと
4. リリース時（タグ push / リリースワークフロー）は従来どおりテストが実行されること

CI 設定のみの変更で、プラグインの動作には影響しません。

関連: vektor-inc/multi-repo-tasks#24
