### PR TITLE
[ 仕様変更 ] 条件タイプ「モバイル端末のみ表示」をデバイス種類の3択に変更

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ However, by nesting Dynamic If Blocks, various conditional branching can be hand
 
 == Changelog ==
 
+* [ Spec Change ] Change the "Mobile Device Only" condition to a "Device Type" selector with No restriction, Mobile Devices Only, and PC Only options.
+
 = 1.6.1 =
 [ Other ] Fix an issue where blocks become locked and cannot be edited when inserting patterns in WordPress 7.0.
 [ Other ] Update vk-helpers library from 0.0.4 to 0.2.1.

--- a/src/constants.js
+++ b/src/constants.js
@@ -34,6 +34,8 @@ export const CONDITION_TYPE_LABELS = {
 	),
 };
 
+// Device type options (No restriction / Mobile Devices Only / PC Only).
+// Stored in values.showOnlyMobileDevice of the mobileDevice condition type.
 // デバイス種類の選択肢（指定なし／モバイル端末のみ表示／PC表示のみ）
 // mobileDevice 条件タイプの values.showOnlyMobileDevice に格納する値
 export const MOBILE_DEVICE_OPTIONS = [
@@ -49,6 +51,14 @@ export const MOBILE_DEVICE_OPTIONS = [
 ];
 
 /**
+ * Normalize the stored value of the mobileDevice condition (which can be either
+ * a boolean or a string) into a string for SelectControl display.
+ *
+ * The old spec stored a boolean toggle (true/false), so the following mapping
+ * is applied for backward compatibility.
+ * - true             → 'mobileOnly' (old toggle ON = Mobile Devices Only)
+ * - false / unset    → 'none' (old toggle OFF / unset = No restriction; never auto-converted to PC Only)
+ *
  * mobileDevice 条件の保存値（真偽値／文字列いずれもあり得る）を
  * SelectControl 表示用の正規化した文字列に変換する。
  *
@@ -57,8 +67,8 @@ export const MOBILE_DEVICE_OPTIONS = [
  * - true          → 'mobileOnly'（旧トグルON = モバイル端末のみ表示）
  * - false／未設定 → 'none'（旧トグルOFF・未設定 = 指定なし。PC専用へは自動変換しない）
  *
- * @param {boolean|string|undefined} rawValue 保存されている値。
- * @return {string} 'none' | 'mobileOnly' | 'pcOnly' のいずれか。
+ * @param {boolean|string|undefined} rawValue The stored value. / 保存されている値。
+ * @return {string} One of 'none' | 'mobileOnly' | 'pcOnly'. / 'none' | 'mobileOnly' | 'pcOnly' のいずれか。
  */
 export const normalizeMobileDeviceValue = ( rawValue ) => {
 	if ( rawValue === true || rawValue === 'mobileOnly' ) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -28,10 +28,46 @@ export const CONDITION_TYPE_LABELS = {
 		'vk-dynamic-if-block'
 	),
 	mobileDevice: _x(
-		'Mobile Device Only',
+		'Device Type',
 		'Condition Type Label',
 		'vk-dynamic-if-block'
 	),
+};
+
+// デバイス種類の選択肢（指定なし／モバイル端末のみ表示／PC表示のみ）
+// mobileDevice 条件タイプの values.showOnlyMobileDevice に格納する値
+export const MOBILE_DEVICE_OPTIONS = [
+	{ value: 'none', label: __( 'No restriction', 'vk-dynamic-if-block' ) },
+	{
+		value: 'mobileOnly',
+		label: __( 'Mobile Devices Only', 'vk-dynamic-if-block' ),
+	},
+	{
+		value: 'pcOnly',
+		label: __( 'PC Only', 'vk-dynamic-if-block' ),
+	},
+];
+
+/**
+ * mobileDevice 条件の保存値（真偽値／文字列いずれもあり得る）を
+ * SelectControl 表示用の正規化した文字列に変換する。
+ *
+ * 旧仕様ではトグルの真偽値（true/false）で保存されていたため、
+ * 後方互換のために以下のマッピングを行う。
+ * - true          → 'mobileOnly'（旧トグルON = モバイル端末のみ表示）
+ * - false／未設定 → 'none'（旧トグルOFF・未設定 = 指定なし。PC専用へは自動変換しない）
+ *
+ * @param {boolean|string|undefined} rawValue 保存されている値。
+ * @return {string} 'none' | 'mobileOnly' | 'pcOnly' のいずれか。
+ */
+export const normalizeMobileDeviceValue = ( rawValue ) => {
+	if ( rawValue === true || rawValue === 'mobileOnly' ) {
+		return 'mobileOnly';
+	}
+	if ( rawValue === 'pcOnly' ) {
+		return 'pcOnly';
+	}
+	return 'none';
 };
 
 // ページタイプ定義

--- a/src/index.js
+++ b/src/index.js
@@ -1521,19 +1521,19 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 								const deviceType = normalizeMobileDeviceValue(
 									values.showOnlyMobileDevice
 								);
-								if ( deviceType === 'mobileOnly' ) {
-									return __(
-										'Mobile Devices Only',
-										'vk-dynamic-if-block'
-									);
+								// Look up the label from MOBILE_DEVICE_OPTIONS instead of
+								// hardcoding it here, so the two never drift apart.
+								// ラベル文字列を MOBILE_DEVICE_OPTIONS から参照する
+								// （ここに直接書かないことで、両者が食い違わないようにする）
+								if ( deviceType === 'none' ) {
+									return null;
 								}
-								if ( deviceType === 'pcOnly' ) {
-									return __(
-										'PC Only',
-										'vk-dynamic-if-block'
-									);
-								}
-								return null;
+								return (
+									MOBILE_DEVICE_OPTIONS.find(
+										( option ) =>
+											option.value === deviceType
+									)?.label ?? null
+								);
 							},
 						};
 

--- a/src/index.js
+++ b/src/index.js
@@ -647,6 +647,10 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 							periodReferCustomField: '',
 						};
 					} else if ( updates.type === 'mobileDevice' ) {
+						// Use "No restriction" as the unrestricted default value
+						// (aligning with the other condition types prevents the
+						// bug where the value became empty right after switching,
+						// making the selection appear to change unintentionally).
 						// 「指定なし」を無制限相当のデフォルト値にする
 						// （他の条件タイプと揃えることで、切り替え直後に
 						// 値が空になり選択肢が意図せず変わって見える不具合を防ぐ）
@@ -1505,6 +1509,10 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 									);
 								}
 							},
+							// condition.type is 'mobileDevice', so the labelMap key
+							// must match it (fixed a bug where the old key
+							// 'showOnlyMobileDevice' didn't match and the label
+							// was never shown).
 							// condition.type は 'mobileDevice' のため、
 							// labelMap のキーもそれに合わせる
 							// （旧キー 'showOnlyMobileDevice' では一致せず

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,8 @@ import {
 	generateId,
 	createConditionGroup,
 	sortLanguages,
+	MOBILE_DEVICE_OPTIONS,
+	normalizeMobileDeviceValue,
 } from './constants';
 
 // グローバル変数の宣言
@@ -644,6 +646,11 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 							periodDisplayValue: '',
 							periodReferCustomField: '',
 						};
+					} else if ( updates.type === 'mobileDevice' ) {
+						// 「指定なし」を無制限相当のデフォルト値にする
+						// （他の条件タイプと揃えることで、切り替え直後に
+						// 値が空になり選択肢が意図せず変わって見える不具合を防ぐ）
+						newValues = { showOnlyMobileDevice: 'none' };
 					} else {
 						newValues = {};
 					}
@@ -1225,15 +1232,16 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 					);
 				},
 				mobileDevice: () => (
-					<ToggleControl
-						label={ __(
-							'Displayed only on mobile devices.',
-							'vk-dynamic-if-block'
+					<SelectControl
+						label={ __( 'Device Type', 'vk-dynamic-if-block' ) }
+						value={ normalizeMobileDeviceValue(
+							values.showOnlyMobileDevice
 						) }
-						checked={ values.showOnlyMobileDevice || false }
-						onChange={ ( checked ) =>
-							updateValue( 'showOnlyMobileDevice', checked )
+						options={ MOBILE_DEVICE_OPTIONS }
+						onChange={ ( value ) =>
+							updateValue( 'showOnlyMobileDevice', value )
 						}
+						__next40pxDefaultSize={ true }
 						__nextHasNoMarginBottom={ true }
 					/>
 				),
@@ -1497,13 +1505,28 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 									);
 								}
 							},
-							showOnlyMobileDevice: () =>
-								values.showOnlyMobileDevice
-									? __(
-											'Mobile Device Only',
-											'vk-dynamic-if-block'
-									  )
-									: null,
+							// condition.type は 'mobileDevice' のため、
+							// labelMap のキーもそれに合わせる
+							// （旧キー 'showOnlyMobileDevice' では一致せず
+							// ラベルが表示されない不具合があったため修正）
+							mobileDevice: () => {
+								const deviceType = normalizeMobileDeviceValue(
+									values.showOnlyMobileDevice
+								);
+								if ( deviceType === 'mobileOnly' ) {
+									return __(
+										'Mobile Devices Only',
+										'vk-dynamic-if-block'
+									);
+								}
+								if ( deviceType === 'pcOnly' ) {
+									return __(
+										'PC Only',
+										'vk-dynamic-if-block'
+									);
+								}
+								return null;
+							},
 						};
 
 						const label =

--- a/src/index.php
+++ b/src/index.php
@@ -375,9 +375,8 @@ function vk_dynamic_if_block_render_old_attributes($attributes, $content)
     }
 
     // Mobile Device Check
-    if (!empty($attributes['showOnlyMobileDevice'])) {
-        $display = $display && wp_is_mobile();
-    }
+    // 「指定なし／モバイル端末のみ表示／PC表示のみ」の3値判定を共通関数に委譲する
+    $display = $display && vk_dynamic_if_block_check_mobile_device($attributes);
 
     // Exclusion Check
     $final_result = ($attributes['exclusion'] ? !$display : $display);
@@ -819,14 +818,33 @@ function vk_dynamic_if_block_check_login_user($values)
 /**
  * Check device type condition.
  *
+ * 'showOnlyMobileDevice' は次の値を取り得る。
+ * - true（真偽値）または 'mobileOnly'（文字列）: モバイル端末のみ表示（旧トグルONと互換）
+ * - 'pcOnly'（文字列）                        : PC表示のみ（新規追加の選択肢）
+ * - 上記以外（false・未設定・'none'・空文字など）: 指定なし（常に表示。旧トグルOFF・未設定と互換）
+ *
+ * 旧仕様（真偽値のトグル）で保存された既存データを「PC表示のみ」へ
+ * 自動変換すると、意図せずモバイル端末で非表示になる事故につながるため、
+ * 旧 false・未設定の値は必ず「指定なし」として扱う（自動的に pcOnly にはしない）。
+ *
  * @param array $values Condition values.
  *
  * @return bool Evaluation result.
  */
 function vk_dynamic_if_block_check_mobile_device($values)
 {
-    return !($values['showOnlyMobileDevice'] ?? false)
-        || wp_is_mobile();
+    $device_type = $values['showOnlyMobileDevice'] ?? false;
+
+    if (true === $device_type || 'mobileOnly' === $device_type) {
+        return wp_is_mobile();
+    }
+
+    if ('pcOnly' === $device_type) {
+        return !wp_is_mobile();
+    }
+
+    // false・未設定・'none'・空文字などは「指定なし」として常に表示する
+    return true;
 }
 
 /*

--- a/src/index.php
+++ b/src/index.php
@@ -375,6 +375,7 @@ function vk_dynamic_if_block_render_old_attributes($attributes, $content)
     }
 
     // Mobile Device Check
+    // Delegate the three-value judgement (No restriction / Mobile Devices Only / PC Only) to the shared function.
     // 「指定なし／モバイル端末のみ表示／PC表示のみ」の3値判定を共通関数に委譲する
     $display = $display && vk_dynamic_if_block_check_mobile_device($attributes);
 
@@ -818,6 +819,15 @@ function vk_dynamic_if_block_check_login_user($values)
 /**
  * Check device type condition.
  *
+ * 'showOnlyMobileDevice' can hold one of the following values.
+ * - true (boolean) or 'mobileOnly' (string): Mobile Devices Only (compatible with the old toggle ON).
+ * - 'pcOnly' (string): PC Only (newly added option).
+ * - anything else (false, unset, 'none', empty string, etc.): No restriction (always display; compatible with the old toggle OFF / unset).
+ *
+ * Automatically converting old data saved with the boolean toggle to "PC Only" risks
+ * unintentionally hiding content on mobile devices, so legacy false/unset values are
+ * always treated as "No restriction" (never auto-converted to pcOnly).
+ *
  * 'showOnlyMobileDevice' は次の値を取り得る。
  * - true（真偽値）または 'mobileOnly'（文字列）: モバイル端末のみ表示（旧トグルONと互換）
  * - 'pcOnly'（文字列）                        : PC表示のみ（新規追加の選択肢）
@@ -843,6 +853,7 @@ function vk_dynamic_if_block_check_mobile_device($values)
         return !wp_is_mobile();
     }
 
+    // false, unset, 'none', empty string, etc. mean "No restriction" and should always display.
     // false・未設定・'none'・空文字などは「指定なし」として常に表示する
     return true;
 }

--- a/src/index.php
+++ b/src/index.php
@@ -837,7 +837,15 @@ function vk_dynamic_if_block_check_login_user($values)
  * 自動変換すると、意図せずモバイル端末で非表示になる事故につながるため、
  * 旧 false・未設定の値は必ず「指定なし」として扱う（自動的に pcOnly にはしない）。
  *
- * @param array $values Condition values.
+ * This function reads 'showOnlyMobileDevice' directly from the given array. It works
+ * whether the caller passes the new-format $condition['values'] or the legacy
+ * $attributes array as a whole, as long as 'showOnlyMobileDevice' is a top-level key.
+ *
+ * この関数は渡された配列から直接 'showOnlyMobileDevice' を読み取る。
+ * 新形式の $condition['values'] を渡しても、旧形式の $attributes 全体を
+ * 渡しても、そのキーが直下にあれば同様に動作する。
+ *
+ * @param array $values Array containing the 'showOnlyMobileDevice' key (either $condition['values'] or the whole $attributes array). / 'showOnlyMobileDevice' キーを含む配列（$condition['values'] または $attributes 全体のいずれか）。
  *
  * @return bool Evaluation result.
  */

--- a/tests/test-dynamic-if.php
+++ b/tests/test-dynamic-if.php
@@ -1232,6 +1232,100 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
         'content'   => 'Mobile device not specified (non-mobile)',
         'expected'  => 'Mobile device not specified (non-mobile)',
         ),
+        // issue #115: 条件タイプ「デバイスの種類」を SelectControl 化したことに伴う新しい3値のテスト
+        // 「指定なし」（'none'）: 常に表示される
+        array(
+        'name'      => 'Device type "No restriction" (mobile)',
+        'go_to'     => get_permalink($test_posts['parent_page_id']),
+        'attribute' => array(
+                    'conditions' => array(
+                        array(
+                            'type'   => 'mobileDevice',
+                            'values' => array( 'showOnlyMobileDevice' => 'none' ),
+                        ),
+        ),
+        ),
+        'is_mobile' => true,
+        'content'   => 'Device type "No restriction" (mobile)',
+        'expected'  => 'Device type "No restriction" (mobile)',
+        ),
+        array(
+        'name'      => 'Device type "No restriction" (non-mobile)',
+        'go_to'     => get_permalink($test_posts['parent_page_id']),
+        'attribute' => array(
+                    'conditions' => array(
+                        array(
+                            'type'   => 'mobileDevice',
+                            'values' => array( 'showOnlyMobileDevice' => 'none' ),
+                        ),
+        ),
+        ),
+        'is_mobile' => false,
+        'content'   => 'Device type "No restriction" (non-mobile)',
+        'expected'  => 'Device type "No restriction" (non-mobile)',
+        ),
+        // 「モバイル端末のみ表示」（'mobileOnly'）: モバイル端末でのみ表示される
+        array(
+        'name'      => 'Device type "Mobile Devices Only" (mobile)',
+        'go_to'     => get_permalink($test_posts['parent_page_id']),
+        'attribute' => array(
+                    'conditions' => array(
+                        array(
+                            'type'   => 'mobileDevice',
+                            'values' => array( 'showOnlyMobileDevice' => 'mobileOnly' ),
+                        ),
+        ),
+        ),
+        'is_mobile' => true,
+        'content'   => 'Device type "Mobile Devices Only" (mobile)',
+        'expected'  => 'Device type "Mobile Devices Only" (mobile)',
+        ),
+        array(
+        'name'      => 'Device type "Mobile Devices Only" (non-mobile)',
+        'go_to'     => get_permalink($test_posts['parent_page_id']),
+        'attribute' => array(
+                    'conditions' => array(
+                        array(
+                            'type'   => 'mobileDevice',
+                            'values' => array( 'showOnlyMobileDevice' => 'mobileOnly' ),
+                        ),
+        ),
+        ),
+        'is_mobile' => false,
+        'content'   => 'Device type "Mobile Devices Only" (non-mobile)',
+        'expected'  => '',
+        ),
+        // 「PC表示のみ」（'pcOnly'）: モバイル端末以外（PC）でのみ表示される。今回新規追加の選択肢
+        array(
+        'name'      => 'Device type "PC Only" (mobile)',
+        'go_to'     => get_permalink($test_posts['parent_page_id']),
+        'attribute' => array(
+                    'conditions' => array(
+                        array(
+                            'type'   => 'mobileDevice',
+                            'values' => array( 'showOnlyMobileDevice' => 'pcOnly' ),
+                        ),
+        ),
+        ),
+        'is_mobile' => true,
+        'content'   => 'Device type "PC Only" (mobile)',
+        'expected'  => '',
+        ),
+        array(
+        'name'      => 'Device type "PC Only" (non-mobile)',
+        'go_to'     => get_permalink($test_posts['parent_page_id']),
+        'attribute' => array(
+                    'conditions' => array(
+                        array(
+                            'type'   => 'mobileDevice',
+                            'values' => array( 'showOnlyMobileDevice' => 'pcOnly' ),
+                        ),
+        ),
+        ),
+        'is_mobile' => false,
+        'content'   => 'Device type "PC Only" (non-mobile)',
+        'expected'  => 'Device type "PC Only" (non-mobile)',
+        ),
         /******************************************
          * Display Period 
 */

--- a/tests/test-dynamic-if.php
+++ b/tests/test-dynamic-if.php
@@ -1232,7 +1232,9 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
         'content'   => 'Mobile device not specified (non-mobile)',
         'expected'  => 'Mobile device not specified (non-mobile)',
         ),
+        // issue #115: New three-value tests following the change of the "Device Type" condition type to a SelectControl.
         // issue #115: 条件タイプ「デバイスの種類」を SelectControl 化したことに伴う新しい3値のテスト
+        // "No restriction" ('none'): always displayed.
         // 「指定なし」（'none'）: 常に表示される
         array(
         'name'      => 'Device type "No restriction" (mobile)',
@@ -1264,6 +1266,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
         'content'   => 'Device type "No restriction" (non-mobile)',
         'expected'  => 'Device type "No restriction" (non-mobile)',
         ),
+        // "Mobile Devices Only" ('mobileOnly'): displayed only on mobile devices.
         // 「モバイル端末のみ表示」（'mobileOnly'）: モバイル端末でのみ表示される
         array(
         'name'      => 'Device type "Mobile Devices Only" (mobile)',
@@ -1295,6 +1298,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
         'content'   => 'Device type "Mobile Devices Only" (non-mobile)',
         'expected'  => '',
         ),
+        // "PC Only" ('pcOnly'): displayed only on non-mobile devices (PC). This is the newly added option.
         // 「PC表示のみ」（'pcOnly'）: モバイル端末以外（PC）でのみ表示される。今回新規追加の選択肢
         array(
         'name'      => 'Device type "PC Only" (mobile)',


### PR DESCRIPTION
## 概要

issue #115 に対応しました。

条件タイプ「モバイル端末のみ表示」のトグルUIが、OFF時に「制限なし（常に表示）」という直感に反する挙動になっていた問題を解消するため、UIを「デバイスの種類」を選ぶ `SelectControl`（指定なし／モバイル端末のみ表示／PC表示のみ）に変更しました。あわせて、条件タイプ切り替え直後に値が空になりトグル表示が意図せずOFFに見えていた根本原因のバグも修正しています。

Closes #115

## 変更内容

- 条件タイプ「モバイル端末のみ表示」のラベルを「Device Type」に変更し、UIを `ToggleControl` から `SelectControl`（指定なし／モバイル端末のみ表示／PC表示のみ）に変更（`src/index.js`, `src/constants.js`）
- PHP側の判定関数 `vk_dynamic_if_block_check_mobile_device()` を新しい3値判定に対応（`src/index.php`）
- 【根本原因の修正】条件タイプ切り替え時のデフォルト値設定ロジックに `mobileDevice` 用の分岐を追加し、切り替え直後に値が空になる不具合を修正
- 条件のラベル表示部分（`labelMap`）で `condition.type`（`mobileDevice`）とキーが一致せずラベルが表示されなかった既存バグも修正
- PHPUnit テストに新しい3状態（指定なし／モバイルのみ／PCのみ）×モバイル/非モバイルの6ケースを追加

## 後方互換性

- 旧トグル `OFF`（および未設定・レガシーデータ）→ 新しい「指定なし（常に表示）」に変換
- 旧トグル `ON` → 「モバイル端末のみ表示」に変換
- **「PC表示のみ」への自動変換は行いません**（意図せずモバイルで非表示になる事故を防ぐため）
- 条件タイプの内部キー（`mobileDevice`）はリネームしていないため、既存の保存データはそのまま新UIに引き継がれます
- 本ブロックは `save()` が属性を出力に反映しない実装のため、`block.json` の `deprecated` 対応は不要です

## 確認手順

### 前提条件
- Dynamic If ブロックを挿入できる投稿またはページ

### Before（修正前の再現手順）
1. 投稿編集画面で「Dynamic If」ブロックを挿入する
2. 条件タイプで「Mobile Device Only」を選択する
3. 表示されるトグルを操作せず（OFFのまま）保存・プレビューする
   → ✗ PC・モバイルどちらでも常に表示されてしまい、「モバイル端末のみ表示」という条件タイプ名から期待される「モバイル以外では非表示」という直感的な挙動と異なる

### After（修正後の確認手順）
1. 投稿編集画面で「Dynamic If」ブロックを挿入する
2. 条件タイプで「Device Type」を選択する
   → ✓ セレクトボックスが表示され、デフォルトで「No restriction（指定なし）」が選択されている
3. 「Mobile Devices Only」を選択して保存する
   → ✓ モバイル端末でアクセスした場合のみ内包ブロックが表示され、PCでは表示されない
4. 「PC Only」を選択して保存する
   → ✓ PC（モバイル以外）でアクセスした場合のみ内包ブロックが表示され、モバイルでは表示されない
5. 「No restriction」を選択して保存する
   → ✓ PC・モバイルどちらでも常に表示される

### デグレ確認（既存データの後方互換）
1. このPRのマージ前に作成された「モバイル端末のみ表示」トグルON状態のブロックを開く
   → ✓ 保存し直しても「Mobile Devices Only」が選択された状態になり、表示挙動が変わらない
2. トグルOFF（または未設定）のまま残っている既存ブロックを開く
   → ✓ 「No restriction」が選択された状態になり、常に表示されたままで、意図せずPC限定表示に変わらない

### 自動テスト
- `npm run phpunit` — 新規追加分含め全て green（`OK (2 tests, 145 assertions)`）
- `npm run lint:js` — 既存エラー数から増加なし

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * モバイル端末条件を「Device Type」に整理し、「制限なし／モバイル端末のみ／PCのみ」を選択できるようになりました（選択式）。
* **不具合修正**
  * 端末種別に応じた表示・ラベルの対応を統一し、旧形式の保存値を読み替えて正しく反映しました。
* **テスト**
  * Device Type の選択内容と端末判定（モバイル／非モバイル）に基づく表示検証ケースを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->