### PR TITLE
[ 開発環境 ] dist smoke test 用 wp-env override ファイル名を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
                   path: dist/
             - name: Create wp-env override for dist smoke test
               run: |
-                printf '{"plugins": ["./dist/%s"]}' "${{ env.plugin_name }}" > wp-env.override.json
+                printf '{"plugins": ["./dist/%s"]}' "${{ env.plugin_name }}" > .wp-env.override.json
             - name: Start wp-env (dist)
               run: |
                 n=0


### PR DESCRIPTION
## 概要

`release.yml` の dist smoke test で使う wp-env override ファイル名が先頭ドット無しの `wp-env.override.json` になっており、wp-env に読み込まれていませんでした。この状態では dist（本番配布物）ではなく source ツリーを smoke test していたことになります。正しい `.wp-env.override.json`（先頭ドット有り）にリネームして修正します。

親 issue vektor-inc/vk-agents#168 の C-7 移行不備監査フォローアップ（issue #136）です。

## 背景・切り分け

issue #136 では2項目が検出候補として挙がっていましたが、実ファイルを確認して切り分けました。

- **① WP-CLI 導入の要否 → 対応不要**: `package.json` の `dist` / `build` は `wp-scripts` + webpack + sass で `wp` コマンドに依存せず、`translate`（`wp i18n make-pot`）スクリプトも release.yml の translate ジョブも存在しないため、WP-CLI 導入ステップは追加不要と判断。
- **② override ファイル名 → 本 PR で修正**: 先頭ドット付きにリネーム。

参照実装（同方針）: vektor-inc/vk-ab-testing `6139ed7` / `7546b93`

## 変更内容

`.github/workflows/release.yml` の `Create wp-env override for dist smoke test` ステップ:

```diff
-                printf '{"plugins": ["./dist/%s"]}' "${{ env.plugin_name }}" > wp-env.override.json
+                printf '{"plugins": ["./dist/%s"]}' "${{ env.plugin_name }}" > .wp-env.override.json
```

## テスト（確認手順）

CI 用のワークフロー修正のため、次のリリースタグ push 時に効果が確認できます。

**Before（修正前の問題）**
1. `release.yml` の test ジョブで `wp-env.override.json`（ドット無し）を生成
2. wp-env はこのファイル名を認識しないため override が効かず、`./dist` 配下の配布物ではなく **source ツリー** が wp-env にマウントされて smoke test されていた
   → 配布物特有のビルド漏れ・ファイル欠落を検知できない

**After（修正後の期待動作）**
1. `.wp-env.override.json`（ドット有り）を生成
2. wp-env が override を読み込み、`./dist/vk-dynamic-if-block`（本番配布物）を対象に smoke test が走る
   → 実際に配布される成果物を検証できる

**ローカルでの簡易確認手順（任意）**
1. プラグインルートで `npm run dist` を実行し `dist/vk-dynamic-if-block` を生成
2. `printf '{"plugins": ["./dist/vk-dynamic-if-block"]}' > .wp-env.override.json`
3. `npm run wp-env start` を実行 → override が読み込まれ、`dist` 配下のプラグインが有効化されることを確認
4. ファイル名を `wp-env.override.json`（ドット無し）に変えて再実行すると override が無視される（＝修正前の状態）ことを確認

changelog: 更新不要（`.github/workflows/*.yml` の変更でエンドユーザーに実害が出ているケースではないため。`rules/changelog.md`「更新不要なケース: GitHub Actions などのワークフロー設定」に該当）

関連 issue: https://github.com/vektor-inc/vk-dynamic-if-block/issues/136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/279