### PR TITLE
[ 開発環境 ] PR テンプレートの関連Issue 欄をフルURL形式に変更

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## 関連Issue
 <!-- 関連するIssueやチケットがあればリンクを貼ってください -->
-- 関連Issue: #[issue番号]
+- 関連Issue: https://github.com/vektor-inc/vk-dynamic-if-block/issues/[issue番号]
 
 
 ## 変更の目的・理由


### PR DESCRIPTION
## 変更の目的・理由

PR テンプレートの関連Issue 欄を `#[issue番号]` 形式からフルURL形式に変更します。

フルURLにすることで、異なるリポジトリのIssueをリンクした際にも正しく参照できるようになります。

## 実装内容

`.github/PULL_REQUEST_TEMPLATE.md` の関連Issue欄を以下のように変更しました。

- 変更前: `- 関連Issue: #[issue番号]`
- 変更後: `- 関連Issue: https://github.com/vektor-inc/vk-dynamic-if-block/issues/[issue番号]`

## 実装者チェックリスト

### コード品質
- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] ワークフローファイルの変更を含んでいない（別PRで対応）
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [x] `readme.txt`に変更内容を記載
- [x] エンドユーザーが理解できる内容で記載

### テスト
- [x] 書けるテストは実装済み
- [x] 既存のテストが通ることを確認
- [x] 手動テストを実施済み

### 最終確認
- [x] このテンプレートの全項目を確認済み
- [x] レビュワーに回す準備が整っている