### PR TITLE
[ 7.1対応 ][ その他 ] WordPress 7.1で不要になったフォームの高さ指定を削除

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -717,7 +717,6 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 					onChange={ ( value ) =>
 						updateValue( 'pageHierarchyType', value )
 					}
-					__next40pxDefaultSize={ true }
 					__nextHasNoMarginBottom={ true }
 				/>
 			);
@@ -732,7 +731,6 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 							onChange={ ( value ) => {
 								updateValue( 'ifPageType', value );
 							} }
-							__next40pxDefaultSize={ true }
 							__nextHasNoMarginBottom={ true }
 						/>
 						{ ( values.ifPageType === 'is_page' || values.ifPageType === 'page' ) && (
@@ -826,7 +824,6 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 							onChange={ ( value ) =>
 								updateValue( 'ifPostType', value )
 							}
-							__next40pxDefaultSize={ true }
 							__nextHasNoMarginBottom={ true }
 						/>
 						{ values.ifPostType === 'page' &&
@@ -856,7 +853,6 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 							onChange={ ( value ) =>
 								updateValue( 'ifLanguage', value )
 							}
-							__next40pxDefaultSize={ true }
 							__nextHasNoMarginBottom={ true }
 						/>
 					);
@@ -988,7 +984,6 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 						onChange={ ( value ) =>
 							updateValue( 'postAuthor', parseInt( value ) || 0 )
 						}
-						__next40pxDefaultSize={ true }
 						__nextHasNoMarginBottom={ true }
 					/>
 				),
@@ -1016,7 +1011,6 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 									onChange={ ( value ) =>
 										updateValue( 'customFieldRule', value )
 									}
-									__next40pxDefaultSize={ true }
 									__nextHasNoMarginBottom={ true }
 								/>
 								{ values.customFieldRule === 'valueEquals' && (
@@ -1050,7 +1044,6 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 							onChange={ ( value ) =>
 								updateValue( 'periodDisplaySetting', value )
 							}
-							__next40pxDefaultSize={ true }
 							__nextHasNoMarginBottom={ true }
 						/>
 						{ values.periodDisplaySetting &&
@@ -1072,7 +1065,6 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 												value
 											)
 										}
-										__next40pxDefaultSize={ true }
 										__nextHasNoMarginBottom={ true }
 									/>
 									{ ( values.periodSpecificationMethod === 'direct' ||
@@ -1199,7 +1191,6 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 										} )
 									);
 								} }
-								__next40pxDefaultSize={ true }
 								__nextHasNoMarginBottom={ true }
 
 							/>
@@ -1228,7 +1219,6 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 												value ? [ value ] : []
 											);
 										} }
-										__next40pxDefaultSize={ true }
 										__nextHasNoMarginBottom={ true }
 									/>
 								) }
@@ -1245,7 +1235,6 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 						onChange={ ( value ) =>
 							updateValue( 'showOnlyMobileDevice', value )
 						}
-						__next40pxDefaultSize={ true }
 						__nextHasNoMarginBottom={ true }
 					/>
 				),
@@ -1694,7 +1683,6 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 																							}
 																						)
 																					}
-																					__next40pxDefaultSize={ true }
 																					__nextHasNoMarginBottom={ true }
 																				/>
 																			</div>
@@ -1767,7 +1755,6 @@ registerBlockType( 'vk-blocks/dynamic-if', {
 															value,
 													} )
 												}
-												__next40pxDefaultSize={ true }
 												__nextHasNoMarginBottom={ true }
 											/>
 										) }


### PR DESCRIPTION
## 関連Issue
- 関連Issue: https://github.com/vektor-inc/multi-repo-tasks/issues/30

## 変更の目的・理由
WordPress 7.1 ではフォームコントロールのデフォルト高さが 40px になり、これまでコンソール警告回避のために付けていた `__next40pxDefaultSize` は実行時に無視される（no-op）ようになりました。不要な指定を削除してコードを整理します。

見た目・挙動の変更はありません。

## 実装内容

### 主な変更点
- [ ] 新機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [x] その他: 不要になった `__next40pxDefaultSize` プロパティの削除

### 技術的な詳細
- 参照: [Editor components updates in WordPress 7.1](https://make.wordpress.org/core/2026/07/23/editor-components-updates-in-wordpress-7-1/)
- `__nextHasNoMarginBottom` はそのまま残しています

## スクリーンショット
見た目の変更がないため省略します。

## 実装者チェックリスト

### コード品質
- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] ワークフローファイルの変更を含んでいない（別PRで対応）
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [x] `readme.txt`に変更内容を記載（エンドユーザー影響なしのため changelog 追記なし）
- [x] エンドユーザーが理解できる内容で記載（該当なし）

### テスト
- [x] 書けるテストは実装済み（UI prop 削除のため単体テスト追加なし）
- [ ] 既存のテストが通ることを確認
- [x] 手動テストを実施済み（削除対象が no-op であることを Field Guide およびローカル 7.1-RC1 で確認）

### 最終確認
- [x] このテンプレートの全項目を確認済み
- [x] レビュワーに回す準備が整っている

---
## レビュワー向け情報

### テスト手順
1. WordPress 7.1（RC1 以上）の環境で本ブランチをビルドして有効化する
2. 投稿編集画面を開き、対象プラグインの設定 UI（サイドバー／ブロック設定）を表示する
3. テキスト入力やセレクトの見た目・操作が従来どおり使えることを確認する
   → フォームが操作でき、コンソールに `__next40pxDefaultSize` 関連の警告が出ない

### レビューポイント（任意）
- 削除漏れがないか（`__next40pxDefaultSize` の残存）
- `__nextHasNoMarginBottom` を誤って消していないか

### 動作確認時の注意事項
- [ ] 最新のコードをプルしている
- [ ] ビルドを実行している
- [ ] 正しいディレクトリで作業している
- [ ] `npm install`を実行している
- [ ] `composer install`を実行している
- [ ] キャッシュをクリアしている

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * 各種選択コントロールの不要なサイズ指定を削除し、余白設定を維持しました。
  * 選択コントロールのデータ処理や条件判定に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->