### PR TITLE
[ 不具合修正 ] リクエスト状態に依存する表示条件を表示判定のキャッシュ対象から除外

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -36,7 +36,7 @@ However, by nesting Dynamic If Blocks, various conditional branching can be hand
 == Changelog ==
 
 * [ Spec Change ] Change the "Mobile Device Only" condition to a "Device Type" selector with No restriction, Mobile Devices Only, and PC Only options.
-* [ Bug Fix ] Fix an issue where display conditions that depend on the request (device type, login state, user role, period and language) could return an incorrect result on sites using a persistent object cache.
+* [ Bug Fix ] Exclude display conditions that depend on the request (device type, login state, user role, display period and language) from the display judgement cache.
 
 = 1.6.1 =
 [ Other ] Fix an issue where blocks become locked and cannot be edited when inserting patterns in WordPress 7.0.

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,7 @@ However, by nesting Dynamic If Blocks, various conditional branching can be hand
 == Changelog ==
 
 * [ Spec Change ] Change the "Mobile Device Only" condition to a "Device Type" selector with No restriction, Mobile Devices Only, and PC Only options.
+* [ Bug Fix ] Fix an issue where display conditions that depend on the request (device type, login state, user role, period and language) could return an incorrect result on sites using a persistent object cache.
 
 = 1.6.1 =
 [ Other ] Fix an issue where blocks become locked and cannot be edited when inserting patterns in WordPress 7.0.

--- a/src/index.php
+++ b/src/index.php
@@ -174,7 +174,7 @@ function vk_dynamic_if_block_render_conditions($attributes, $content)
     $cache_key = '';
     if (! $skip_cache) {
         // 条件評価の結果をキャッシュするためのキーを生成
-        $cache_key = 'vk_dynamic_if_block_' . md5(serialize($attributes) . serialize($content) . get_the_ID() . get_queried_object_id());
+        $cache_key = vk_dynamic_if_block_get_cache_key($attributes, $content, 'vk_dynamic_if_block_');
 
         // キャッシュから結果を取得
         $cached_result = wp_cache_get($cache_key, 'vk_dynamic_if_block');
@@ -262,7 +262,7 @@ function vk_dynamic_if_block_render_old_attributes($attributes, $content)
     $cache_key = '';
     if (! $skip_cache) {
         // 条件評価の結果をキャッシュするためのキーを生成
-        $cache_key = 'vk_dynamic_if_block_old_' . md5(serialize($attributes) . serialize($content) . get_the_ID() . get_queried_object_id());
+        $cache_key = vk_dynamic_if_block_get_cache_key($attributes, $content, 'vk_dynamic_if_block_old_');
 
         // キャッシュから結果を取得
         $cached_result = wp_cache_get($cache_key, 'vk_dynamic_if_block');
@@ -416,6 +416,27 @@ function vk_dynamic_if_block_render_old_attributes($attributes, $content)
 
         return $result_content;
     }
+}
+
+/**
+ * Build the cache key for the display judgement.
+ *
+ * The key is built from the block attributes, the block content, the current post and the
+ * queried object, so that a different block or a different page never shares the same key.
+ *
+ * 表示判定の結果をキャッシュするためのキーを組み立てる。
+ * ブロックの属性・中身・表示中の投稿・クエリ対象から組み立てるため、
+ * 別のブロックや別のページが同じキーを共有することはない。
+ *
+ * @param array  $attributes Block attributes. / ブロックの属性。
+ * @param string $content    Block content. / ブロックの中身。
+ * @param string $prefix     Key prefix. / キーの接頭辞。
+ *
+ * @return string Cache key. / キャッシュキー。
+ */
+function vk_dynamic_if_block_get_cache_key($attributes, $content, $prefix)
+{
+    return $prefix . md5(serialize($attributes) . serialize($content) . get_the_ID() . get_queried_object_id());
 }
 
 /**

--- a/src/index.php
+++ b/src/index.php
@@ -167,17 +167,24 @@ function vk_dynamic_if_block_render_conditions($attributes, $content)
         return $content;
     }
 
-    // 条件評価の結果をキャッシュするためのキーを生成
-    $cache_key = 'vk_dynamic_if_block_' . md5(serialize($attributes) . serialize($content) . get_the_ID() . get_queried_object_id());
+    // Conditions that depend on per-request state must not be cached across requests.
+    // リクエストごとに変わる状態に依存する条件は、リクエストをまたいでキャッシュしてはいけない
+    $skip_cache = vk_dynamic_if_block_has_request_state_condition($attributes);
 
-    // キャッシュから結果を取得
-    $cached_result = wp_cache_get($cache_key, 'vk_dynamic_if_block');
-    if ($cached_result !== false) {
-        // キャッシュされた結果を使用
-        if ($cached_result === 'true') {
-            return vk_dynamic_if_block_extract_content_without_else($content);
-        } elseif ($cached_result === 'false') {
-            return vk_dynamic_if_block_extract_else_content($content);
+    $cache_key = '';
+    if (! $skip_cache) {
+        // 条件評価の結果をキャッシュするためのキーを生成
+        $cache_key = 'vk_dynamic_if_block_' . md5(serialize($attributes) . serialize($content) . get_the_ID() . get_queried_object_id());
+
+        // キャッシュから結果を取得
+        $cached_result = wp_cache_get($cache_key, 'vk_dynamic_if_block');
+        if ($cached_result !== false) {
+            // キャッシュされた結果を使用
+            if ($cached_result === 'true') {
+                return vk_dynamic_if_block_extract_content_without_else($content);
+            } elseif ($cached_result === 'false') {
+                return vk_dynamic_if_block_extract_else_content($content);
+            }
         }
     }
 
@@ -216,8 +223,10 @@ function vk_dynamic_if_block_render_conditions($attributes, $content)
 
     $final_result = ($attributes['exclusion'] ? !$display : $display);
 
-    // 結果をキャッシュに保存（1分間有効）
-    wp_cache_set($cache_key, $final_result ? 'true' : 'false', 'vk_dynamic_if_block', 60);
+    if (! $skip_cache) {
+        // 結果をキャッシュに保存（1分間有効）
+        wp_cache_set($cache_key, $final_result ? 'true' : 'false', 'vk_dynamic_if_block', 60);
+    }
 
 
     // elseブロックの処理
@@ -246,17 +255,24 @@ function vk_dynamic_if_block_render_conditions($attributes, $content)
  */
 function vk_dynamic_if_block_render_old_attributes($attributes, $content)
 {
-    // 条件評価の結果をキャッシュするためのキーを生成
-    $cache_key = 'vk_dynamic_if_block_old_' . md5(serialize($attributes) . serialize($content) . get_the_ID() . get_queried_object_id());
+    // Conditions that depend on per-request state must not be cached across requests.
+    // リクエストごとに変わる状態に依存する条件は、リクエストをまたいでキャッシュしてはいけない
+    $skip_cache = vk_dynamic_if_block_has_request_state_condition($attributes);
 
-    // キャッシュから結果を取得
-    $cached_result = wp_cache_get($cache_key, 'vk_dynamic_if_block');
-    if ($cached_result !== false) {
-        // キャッシュされた結果を使用
-        if ($cached_result === 'true') {
-            return vk_dynamic_if_block_extract_content_without_else($content);
-        } elseif ($cached_result === 'false') {
-            return vk_dynamic_if_block_extract_else_content($content);
+    $cache_key = '';
+    if (! $skip_cache) {
+        // 条件評価の結果をキャッシュするためのキーを生成
+        $cache_key = 'vk_dynamic_if_block_old_' . md5(serialize($attributes) . serialize($content) . get_the_ID() . get_queried_object_id());
+
+        // キャッシュから結果を取得
+        $cached_result = wp_cache_get($cache_key, 'vk_dynamic_if_block');
+        if ($cached_result !== false) {
+            // キャッシュされた結果を使用
+            if ($cached_result === 'true') {
+                return vk_dynamic_if_block_extract_content_without_else($content);
+            } elseif ($cached_result === 'false') {
+                return vk_dynamic_if_block_extract_else_content($content);
+            }
         }
     }
 
@@ -382,8 +398,10 @@ function vk_dynamic_if_block_render_old_attributes($attributes, $content)
     // Exclusion Check
     $final_result = ($attributes['exclusion'] ? !$display : $display);
 
-    // 結果をキャッシュに保存（1分間有効）
-    wp_cache_set($cache_key, $final_result ? 'true' : 'false', 'vk_dynamic_if_block', 60);
+    if (! $skip_cache) {
+        // 結果をキャッシュに保存（1分間有効）
+        wp_cache_set($cache_key, $final_result ? 'true' : 'false', 'vk_dynamic_if_block', 60);
+    }
 
     // elseブロックの処理
     if ($final_result) {
@@ -398,6 +416,146 @@ function vk_dynamic_if_block_render_old_attributes($attributes, $content)
 
         return $result_content;
     }
+}
+
+/**
+ * Get the condition types that depend on per-request state.
+ *
+ * The result of these condition types changes per request even when the block attributes,
+ * the block content and the current post are exactly the same, because they depend on the
+ * device, the login state, the capability of the current user, or the current time.
+ * They must never be shared between requests through a persistent object cache.
+ *
+ * これらの条件タイプは、ブロックの属性・中身・表示中の投稿がまったく同じでも、
+ * 端末種別・ログイン状態・ユーザー権限・現在時刻に依存するためリクエストごとに結果が変わる。
+ * 永続オブジェクトキャッシュでリクエストをまたいで共有してはいけない。
+ *
+ * @return array List of condition type slugs. / 条件タイプのスラッグ一覧。
+ */
+function vk_dynamic_if_block_get_request_state_condition_types()
+{
+    return array(
+        // Device type (wp_is_mobile()). / 端末種別（wp_is_mobile()）
+        'mobileDevice',
+        // Login state (is_user_logged_in()). / ログイン状態（is_user_logged_in()）
+        'loginUser',
+        // Capability of the current user. / 現在のユーザーの権限
+        'userRole',
+        // Current time. / 現在時刻
+        'period',
+    );
+}
+
+/**
+ * Check whether the given condition list contains a request state dependent condition.
+ *
+ * Each element of the list may hold a nested condition list under the 'conditions' key,
+ * so the list is scanned recursively.
+ *
+ * 各要素は 'conditions' キーに入れ子の条件配列を持つことがあるため、再帰的に走査する。
+ *
+ * @param mixed $conditions Condition list. / 条件の配列。
+ *
+ * @return bool True when at least one request state dependent condition is found. / リクエスト状態に依存する条件が1つでもあれば true。
+ */
+function vk_dynamic_if_block_has_request_state_condition_in_conditions($conditions)
+{
+    if (! is_array($conditions)) {
+        return false;
+    }
+
+    $request_state_types = vk_dynamic_if_block_get_request_state_condition_types();
+
+    foreach ($conditions as $condition) {
+        if (! is_array($condition)) {
+            continue;
+        }
+
+        // Check the condition type of this element. / この要素自身の条件タイプを判定する
+        if (isset($condition['type']) && in_array($condition['type'], $request_state_types, true)) {
+            return true;
+        }
+
+        // Scan the nested condition list. / 入れ子の条件配列を走査する
+        if (
+            isset($condition['conditions'])
+            && vk_dynamic_if_block_has_request_state_condition_in_conditions($condition['conditions'])
+        ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Check whether the given block attributes contain a request state dependent condition.
+ *
+ * Supports both the current attribute structure ('conditions' / 'groups') and the legacy
+ * attribute structure, so that both render functions can share this single judgement.
+ *
+ * 現行の属性構造（'conditions' / 'groups'）と旧属性構造の両方に対応し、
+ * 2つのレンダー関数が同じ判定を共有できるようにしている。
+ *
+ * @param mixed $attributes Block attributes. / ブロックの属性。
+ *
+ * @return bool True when the block must not be cached. / キャッシュしてはいけない場合に true。
+ */
+function vk_dynamic_if_block_has_request_state_condition($attributes)
+{
+    if (! is_array($attributes)) {
+        return false;
+    }
+
+    // Current structure: the 'conditions' list. / 現行構造: 'conditions' の配列
+    if (
+        isset($attributes['conditions'])
+        && vk_dynamic_if_block_has_request_state_condition_in_conditions($attributes['conditions'])
+    ) {
+        return true;
+    }
+
+    // Current structure: each group holds its own 'conditions' list. / 現行構造: 各グループが持つ 'conditions' の配列
+    if (isset($attributes['groups']) && is_array($attributes['groups'])) {
+        foreach ($attributes['groups'] as $group) {
+            if (
+                is_array($group)
+                && isset($group['conditions'])
+                && vk_dynamic_if_block_has_request_state_condition_in_conditions($group['conditions'])
+            ) {
+                return true;
+            }
+        }
+    }
+
+    // Legacy structure: capability of the current user. / 旧構造: 現在のユーザーの権限
+    if (! empty($attributes['userRole'])) {
+        return true;
+    }
+
+    // Legacy structure: login state. / 旧構造: ログイン状態
+    if (! empty($attributes['showOnlyLoginUser'])) {
+        return true;
+    }
+
+    // Legacy structure: current time.
+    // 'none' and empty values mean "no restriction", so they are not request state dependent.
+    // 旧構造: 現在時刻。'none' や空値は「指定なし」なのでリクエスト状態に依存しない
+    if (! empty($attributes['periodDisplaySetting']) && 'none' !== $attributes['periodDisplaySetting']) {
+        return true;
+    }
+
+    // Legacy structure: device type.
+    // Only the values that actually restrict the display are treated as request state dependent,
+    // in the same way as vk_dynamic_if_block_check_mobile_device().
+    // 旧構造: 端末種別。vk_dynamic_if_block_check_mobile_device() と同じく、
+    // 実際に表示を制限する値のみをリクエスト状態に依存するものとして扱う
+    $device_type = $attributes['showOnlyMobileDevice'] ?? false;
+    if (true === $device_type || 'mobileOnly' === $device_type || 'pcOnly' === $device_type) {
+        return true;
+    }
+
+    return false;
 }
 
 /**

--- a/src/index.php
+++ b/src/index.php
@@ -423,11 +423,13 @@ function vk_dynamic_if_block_render_old_attributes($attributes, $content)
  *
  * The result of these condition types changes per request even when the block attributes,
  * the block content and the current post are exactly the same, because they depend on the
- * device, the login state, the capability of the current user, or the current time.
+ * device, the login state, the capability of the current user, the current time, or the
+ * locale of the visitor.
  * They must never be shared between requests through a persistent object cache.
  *
  * これらの条件タイプは、ブロックの属性・中身・表示中の投稿がまったく同じでも、
- * 端末種別・ログイン状態・ユーザー権限・現在時刻に依存するためリクエストごとに結果が変わる。
+ * 端末種別・ログイン状態・ユーザー権限・現在時刻・訪問者の言語に依存するため、
+ * リクエストごとに結果が変わる。
  * 永続オブジェクトキャッシュでリクエストをまたいで共有してはいけない。
  *
  * @return array List of condition type slugs. / 条件タイプのスラッグ一覧。
@@ -443,6 +445,11 @@ function vk_dynamic_if_block_get_request_state_condition_types()
         'userRole',
         // Current time. / 現在時刻
         'period',
+        // Locale. get_locale() goes through the 'locale' filter, so multilingual plugins
+        // such as Polylang and WPML make it vary by visitor.
+        // 言語。get_locale() は 'locale' フィルターを通るため、Polylang や WPML などの
+        // 多言語プラグインが入った環境では訪問者ごとに値が変わる
+        'language',
     );
 }
 
@@ -535,6 +542,15 @@ function vk_dynamic_if_block_has_request_state_condition($attributes)
 
     // Legacy structure: login state. / 旧構造: ログイン状態
     if (! empty($attributes['showOnlyLoginUser'])) {
+        return true;
+    }
+
+    // Legacy structure: locale.
+    // Matches the evaluation in vk_dynamic_if_block_render_old_attributes(), which skips
+    // the check when the value is empty or 'none' ("no restriction").
+    // 旧構造: 言語。vk_dynamic_if_block_render_old_attributes() の評価と同じく、
+    // 空値と 'none'（指定なし）のときは判定自体が行われないため対象外とする
+    if (! empty($attributes['ifLanguage']) && 'none' !== $attributes['ifLanguage']) {
         return true;
     }
 

--- a/src/index.php
+++ b/src/index.php
@@ -422,11 +422,13 @@ function vk_dynamic_if_block_render_old_attributes($attributes, $content)
  * Build the cache key for the display judgement.
  *
  * The key is built from the block attributes, the block content, the current post and the
- * queried object, so that a different block or a different page never shares the same key.
+ * queried object. Note that pages where both get_the_ID() and get_queried_object_id() are
+ * unavailable (search results, 404, post type archives, etc.) produce the same key.
  *
  * 表示判定の結果をキャッシュするためのキーを組み立てる。
- * ブロックの属性・中身・表示中の投稿・クエリ対象から組み立てるため、
- * 別のブロックや別のページが同じキーを共有することはない。
+ * ブロックの属性・中身・表示中の投稿・クエリ対象から組み立てる。
+ * ただし get_the_ID() と get_queried_object_id() のどちらも得られないページ
+ * （検索結果・404・投稿タイプアーカイブなど）同士では同じキーになる点に注意。
  *
  * @param array  $attributes Block attributes. / ブロックの属性。
  * @param string $content    Block content. / ブロックの中身。

--- a/tests/test-dynamic-if.php
+++ b/tests/test-dynamic-if.php
@@ -2777,6 +2777,18 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                 'expected'            => true,
             ),
             array(
+                'test_condition_name' => 'conditions に言語が含まれる場合 => true',
+                'attributes'          => array(
+                    'conditions' => array(
+                        array(
+                            'type'   => 'language',
+                            'values' => array( 'ifLanguage' => 'en_US' ),
+                        ),
+                    ),
+                ),
+                'expected'            => true,
+            ),
+            array(
                 'test_condition_name' => 'ネストされた条件の中だけに端末種別がある場合 => true',
                 'attributes'          => array(
                     'conditions' => array(
@@ -2869,6 +2881,16 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
                 'expected'            => false,
             ),
             array(
+                'test_condition_name' => '旧属性で言語が指定されている場合 => true',
+                'attributes'          => array( 'ifLanguage' => 'en_US' ),
+                'expected'            => true,
+            ),
+            array(
+                'test_condition_name' => '旧属性で言語が none の場合 => false',
+                'attributes'          => array( 'ifLanguage' => 'none' ),
+                'expected'            => false,
+            ),
+            array(
                 'test_condition_name' => '旧属性で期間指定（公開終了日時）が指定されている場合 => true',
                 'attributes'          => array( 'periodDisplaySetting' => 'deadline' ),
                 'expected'            => true,
@@ -2920,6 +2942,241 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
 
             // 期待値テスト
             $this->assertSame($case['expected'], $actual, $case['test_condition_name']);
+        }
+    }
+
+    /**
+     * 新しい属性構造でのキャッシュ利用有無のテスト
+     *
+     * リクエスト状態に依存する条件を含む場合はキャッシュの読み書きを行わず、
+     * 含まない場合は従来どおりキャッシュを利用することを確認する。
+     */
+    public function test_vk_dynamic_if_block_render_conditions()
+    {
+        // else ブロックを含むコンテンツと、条件成立時・不成立時それぞれの出力
+        $content     = '<p>main</p><div class="vk-dynamic-if-else-block__content">else</div>';
+        $main_output = '<p>main</p>';
+        $else_output = '<div class="vk-dynamic-if-else-block__content">else</div>';
+
+        // 常に true になる条件（ページ種別の指定なし）
+        $not_request_state_condition = array(
+            'type'   => 'pageType',
+            'values' => array( 'ifPageType' => 'none' ),
+        );
+
+        // テストの配列
+        // seed         : レンダー前にキャッシュへ仕込む値（null なら仕込まない）
+        // expected     : レンダー結果の期待値
+        // expected_cache : レンダー後にキャッシュへ保存されている値の期待値（キーが無い場合は検証しない）
+        $test_cases = array(
+            array(
+                'test_condition_name' => 'リクエスト状態に依存しない条件で、逆の値をキャッシュに仕込んだ場合 => キャッシュが使われて else が返る',
+                'attributes'          => array(
+                    'conditions' => array( $not_request_state_condition ),
+                    'exclusion'  => false,
+                ),
+                'seed'                => 'false',
+                'expected'            => $else_output,
+            ),
+            array(
+                'test_condition_name' => 'リクエスト状態に依存しない条件で、キャッシュが空の場合 => 判定結果がキャッシュへ保存される',
+                'attributes'          => array(
+                    'conditions' => array( $not_request_state_condition ),
+                    'exclusion'  => false,
+                ),
+                'seed'                => null,
+                'expected'            => $main_output,
+                'expected_cache'      => 'true',
+            ),
+            array(
+                'test_condition_name' => 'ログイン状態の条件を含み、逆の値をキャッシュに仕込んだ場合 => 仕込み値は使われず main が返る',
+                'attributes'          => array(
+                    'conditions' => array(
+                        $not_request_state_condition,
+                        array(
+                            'type'   => 'loginUser',
+                            'values' => array( 'showOnlyLoginUser' => false ),
+                        ),
+                    ),
+                    'exclusion'  => false,
+                ),
+                'seed'                => 'false',
+                'expected'            => $main_output,
+            ),
+            array(
+                'test_condition_name' => 'ログイン状態の条件を含み、キャッシュが空の場合 => キャッシュへ保存されない',
+                'attributes'          => array(
+                    'conditions' => array(
+                        $not_request_state_condition,
+                        array(
+                            'type'   => 'loginUser',
+                            'values' => array( 'showOnlyLoginUser' => false ),
+                        ),
+                    ),
+                    'exclusion'  => false,
+                ),
+                'seed'                => null,
+                'expected'            => $main_output,
+                'expected_cache'      => false,
+            ),
+            array(
+                'test_condition_name' => 'ネストされた条件の中だけに端末種別があり、逆の値をキャッシュに仕込んだ場合 => 仕込み値は使われず main が返る',
+                'attributes'          => array(
+                    'conditions' => array(
+                        array(
+                            'conditions' => array(
+                                array(
+                                    'type'   => 'mobileDevice',
+                                    'values' => array( 'showOnlyMobileDevice' => 'pcOnly' ),
+                                ),
+                            ),
+                        ),
+                    ),
+                    'exclusion'  => false,
+                ),
+                'seed'                => 'false',
+                'expected'            => $main_output,
+            ),
+            array(
+                'test_condition_name' => '言語の条件を含み、逆の値をキャッシュに仕込んだ場合 => 仕込み値は使われず main が返る',
+                'attributes'          => array(
+                    'conditions' => array(
+                        array(
+                            'type'   => 'language',
+                            'values' => array( 'ifLanguage' => get_locale() ),
+                        ),
+                    ),
+                    'exclusion'  => false,
+                ),
+                'seed'                => 'false',
+                'expected'            => $main_output,
+            ),
+        );
+
+        foreach ( $test_cases as $case ) {
+            // レンダー関数と同じ計算式でキャッシュキーを組み立てる
+            $cache_key = 'vk_dynamic_if_block_' . md5(serialize($case['attributes']) . serialize($content) . get_the_ID() . get_queried_object_id());
+
+            // 前のケースの残りを消してから仕込む
+            wp_cache_delete($cache_key, 'vk_dynamic_if_block');
+            if ($case['seed'] !== null ) {
+                wp_cache_set($cache_key, $case['seed'], 'vk_dynamic_if_block', 60);
+            }
+
+            // テスト関数実行
+            $actual = vk_dynamic_if_block_render_conditions($case['attributes'], $content);
+
+            // 期待値テスト
+            $this->assertSame($case['expected'], $actual, $case['test_condition_name']);
+
+            // キャッシュへの書き込み有無テスト
+            if (array_key_exists('expected_cache', $case) ) {
+                $this->assertSame(
+                    $case['expected_cache'],
+                    wp_cache_get($cache_key, 'vk_dynamic_if_block'),
+                    $case['test_condition_name']
+                );
+            }
+
+            // 後始末
+            wp_cache_delete($cache_key, 'vk_dynamic_if_block');
+        }
+    }
+
+    /**
+     * 旧属性構造でのキャッシュ利用有無のテスト
+     *
+     * リクエスト状態に依存する条件を含む場合はキャッシュの読み書きを行わず、
+     * 含まない場合は従来どおりキャッシュを利用することを確認する。
+     */
+    public function test_vk_dynamic_if_block_render_old_attributes()
+    {
+        // else ブロックを含むコンテンツと、条件成立時・不成立時それぞれの出力
+        $content     = '<p>main</p><div class="vk-dynamic-if-else-block__content">else</div>';
+        $main_output = '<p>main</p>';
+        $else_output = '<div class="vk-dynamic-if-else-block__content">else</div>';
+
+        // テストの配列
+        $test_cases = array(
+            array(
+                'test_condition_name' => '旧属性でリクエスト状態に依存しない条件のみ、逆の値をキャッシュに仕込んだ場合 => キャッシュが使われて else が返る',
+                'attributes'          => array(
+                    'ifPageType' => 'none',
+                    'exclusion'  => false,
+                ),
+                'seed'                => 'false',
+                'expected'            => $else_output,
+            ),
+            array(
+                'test_condition_name' => '旧属性でリクエスト状態に依存しない条件のみ、キャッシュが空の場合 => 判定結果がキャッシュへ保存される',
+                'attributes'          => array(
+                    'ifPageType' => 'none',
+                    'exclusion'  => false,
+                ),
+                'seed'                => null,
+                'expected'            => $main_output,
+                'expected_cache'      => 'true',
+            ),
+            array(
+                'test_condition_name' => '旧属性で言語を指定し、逆の値をキャッシュに仕込んだ場合 => 仕込み値は使われず main が返る',
+                'attributes'          => array(
+                    'ifLanguage' => get_locale(),
+                    'exclusion'  => false,
+                ),
+                'seed'                => 'false',
+                'expected'            => $main_output,
+            ),
+            array(
+                'test_condition_name' => '旧属性でログインユーザーのみ表示を指定し（未ログイン）、逆の値をキャッシュに仕込んだ場合 => 仕込み値は使われず else が返る',
+                'attributes'          => array(
+                    'showOnlyLoginUser' => true,
+                    'exclusion'         => false,
+                ),
+                'seed'                => 'true',
+                'expected'            => $else_output,
+            ),
+            array(
+                'test_condition_name' => '旧属性で端末種別に PC 表示のみを指定し、キャッシュが空の場合 => キャッシュへ保存されない',
+                'attributes'          => array(
+                    'showOnlyMobileDevice' => 'pcOnly',
+                    'exclusion'            => false,
+                ),
+                'seed'                => null,
+                'expected'            => $main_output,
+                'expected_cache'      => false,
+            ),
+        );
+
+        // 未ログイン状態であることを保証する（ログインユーザー条件のケースの前提）
+        wp_set_current_user(0);
+
+        foreach ( $test_cases as $case ) {
+            // レンダー関数と同じ計算式でキャッシュキーを組み立てる
+            $cache_key = 'vk_dynamic_if_block_old_' . md5(serialize($case['attributes']) . serialize($content) . get_the_ID() . get_queried_object_id());
+
+            // 前のケースの残りを消してから仕込む
+            wp_cache_delete($cache_key, 'vk_dynamic_if_block');
+            if ($case['seed'] !== null ) {
+                wp_cache_set($cache_key, $case['seed'], 'vk_dynamic_if_block', 60);
+            }
+
+            // テスト関数実行
+            $actual = vk_dynamic_if_block_render_old_attributes($case['attributes'], $content);
+
+            // 期待値テスト
+            $this->assertSame($case['expected'], $actual, $case['test_condition_name']);
+
+            // キャッシュへの書き込み有無テスト
+            if (array_key_exists('expected_cache', $case) ) {
+                $this->assertSame(
+                    $case['expected_cache'],
+                    wp_cache_get($cache_key, 'vk_dynamic_if_block'),
+                    $case['test_condition_name']
+                );
+            }
+
+            // 後始末
+            wp_cache_delete($cache_key, 'vk_dynamic_if_block');
         }
     }
 

--- a/tests/test-dynamic-if.php
+++ b/tests/test-dynamic-if.php
@@ -2691,4 +2691,236 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
         wp_delete_post($test_posts['home_page_id'], true);
     }
 
+    /**
+     * リクエスト状態に依存する条件が含まれるかの判定テスト
+     *
+     * 端末種別・ログイン状態・ユーザー権限・時刻に依存する条件を含む場合、
+     * 表示判定の結果をリクエストをまたいでキャッシュしてはいけないため true を返す。
+     */
+    public function test_vk_dynamic_if_block_has_request_state_condition()
+    {
+        // テストの配列
+        $test_cases = array(
+            array(
+                'test_condition_name' => '条件が空の配列の場合 => false',
+                'attributes'          => array(),
+                'expected'            => false,
+            ),
+            array(
+                'test_condition_name' => '属性が配列でない場合 => false',
+                'attributes'          => 'not-an-array',
+                'expected'            => false,
+            ),
+            array(
+                'test_condition_name' => 'conditions が配列でない場合 => false',
+                'attributes'          => array( 'conditions' => 'not-an-array' ),
+                'expected'            => false,
+            ),
+            array(
+                'test_condition_name' => 'conditions がページタイプのみの場合 => false',
+                'attributes'          => array(
+                    'conditions' => array(
+                        array(
+                            'type'   => 'pageType',
+                            'values' => array( 'ifPageType' => 'is_single' ),
+                        ),
+                    ),
+                ),
+                'expected'            => false,
+            ),
+            array(
+                'test_condition_name' => 'conditions に端末種別が含まれる場合 => true',
+                'attributes'          => array(
+                    'conditions' => array(
+                        array(
+                            'type'   => 'mobileDevice',
+                            'values' => array( 'showOnlyMobileDevice' => 'mobileOnly' ),
+                        ),
+                    ),
+                ),
+                'expected'            => true,
+            ),
+            array(
+                'test_condition_name' => 'conditions にログイン状態が含まれる場合 => true',
+                'attributes'          => array(
+                    'conditions' => array(
+                        array(
+                            'type'   => 'loginUser',
+                            'values' => array( 'showOnlyLoginUser' => true ),
+                        ),
+                    ),
+                ),
+                'expected'            => true,
+            ),
+            array(
+                'test_condition_name' => 'conditions にユーザー権限が含まれる場合 => true',
+                'attributes'          => array(
+                    'conditions' => array(
+                        array(
+                            'type'   => 'userRole',
+                            'values' => array( 'userRole' => array( 'editor' ) ),
+                        ),
+                    ),
+                ),
+                'expected'            => true,
+            ),
+            array(
+                'test_condition_name' => 'conditions に期間指定が含まれる場合 => true',
+                'attributes'          => array(
+                    'conditions' => array(
+                        array(
+                            'type'   => 'period',
+                            'values' => array( 'periodDisplaySetting' => 'deadline' ),
+                        ),
+                    ),
+                ),
+                'expected'            => true,
+            ),
+            array(
+                'test_condition_name' => 'ネストされた条件の中だけに端末種別がある場合 => true',
+                'attributes'          => array(
+                    'conditions' => array(
+                        array(
+                            'type'   => 'pageType',
+                            'values' => array( 'ifPageType' => 'is_single' ),
+                        ),
+                        array(
+                            'conditions' => array(
+                                array(
+                                    'type'   => 'mobileDevice',
+                                    'values' => array( 'showOnlyMobileDevice' => 'pcOnly' ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                'expected'            => true,
+            ),
+            array(
+                'test_condition_name' => '2階層ネストされた条件の中だけにログイン状態がある場合 => true',
+                'attributes'          => array(
+                    'conditions' => array(
+                        array(
+                            'conditions' => array(
+                                array(
+                                    'conditions' => array(
+                                        array(
+                                            'type'   => 'loginUser',
+                                            'values' => array( 'showOnlyLoginUser' => true ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                'expected'            => true,
+            ),
+            array(
+                'test_condition_name' => 'ネストされた条件がリクエスト状態に依存しない場合 => false',
+                'attributes'          => array(
+                    'conditions' => array(
+                        array(
+                            'conditions' => array(
+                                array(
+                                    'type'   => 'postType',
+                                    'values' => array( 'ifPostType' => 'post' ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                'expected'            => false,
+            ),
+            array(
+                'test_condition_name' => 'groups の中だけにユーザー権限がある場合 => true',
+                'attributes'          => array(
+                    'groups' => array(
+                        array(
+                            'conditions' => array(
+                                array(
+                                    'type'   => 'userRole',
+                                    'values' => array( 'userRole' => array( 'administrator' ) ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                'expected'            => true,
+            ),
+            array(
+                'test_condition_name' => '旧属性でユーザー権限が指定されている場合 => true',
+                'attributes'          => array( 'userRole' => array( 'editor' ) ),
+                'expected'            => true,
+            ),
+            array(
+                'test_condition_name' => '旧属性でユーザー権限が空配列の場合 => false',
+                'attributes'          => array( 'userRole' => array() ),
+                'expected'            => false,
+            ),
+            array(
+                'test_condition_name' => '旧属性でログインユーザーのみ表示が指定されている場合 => true',
+                'attributes'          => array( 'showOnlyLoginUser' => true ),
+                'expected'            => true,
+            ),
+            array(
+                'test_condition_name' => '旧属性でログインユーザーのみ表示が空文字の場合 => false',
+                'attributes'          => array( 'showOnlyLoginUser' => '' ),
+                'expected'            => false,
+            ),
+            array(
+                'test_condition_name' => '旧属性で期間指定（公開終了日時）が指定されている場合 => true',
+                'attributes'          => array( 'periodDisplaySetting' => 'deadline' ),
+                'expected'            => true,
+            ),
+            array(
+                'test_condition_name' => '旧属性で期間指定が none の場合 => false',
+                'attributes'          => array( 'periodDisplaySetting' => 'none' ),
+                'expected'            => false,
+            ),
+            array(
+                'test_condition_name' => '旧属性で端末種別がモバイル端末のみ（旧トグルON）の場合 => true',
+                'attributes'          => array( 'showOnlyMobileDevice' => true ),
+                'expected'            => true,
+            ),
+            array(
+                'test_condition_name' => '旧属性で端末種別が mobileOnly の場合 => true',
+                'attributes'          => array( 'showOnlyMobileDevice' => 'mobileOnly' ),
+                'expected'            => true,
+            ),
+            array(
+                'test_condition_name' => '旧属性で端末種別が pcOnly の場合 => true',
+                'attributes'          => array( 'showOnlyMobileDevice' => 'pcOnly' ),
+                'expected'            => true,
+            ),
+            array(
+                'test_condition_name' => '旧属性で端末種別が none（指定なし）の場合 => false',
+                'attributes'          => array( 'showOnlyMobileDevice' => 'none' ),
+                'expected'            => false,
+            ),
+            array(
+                'test_condition_name' => '旧属性で端末種別が false（旧トグルOFF）の場合 => false',
+                'attributes'          => array( 'showOnlyMobileDevice' => false ),
+                'expected'            => false,
+            ),
+            array(
+                'test_condition_name' => '旧属性でリクエスト状態に依存しない条件のみの場合 => false',
+                'attributes'          => array(
+                    'ifPageType'      => 'is_single',
+                    'ifPostType'      => 'post',
+                    'customFieldName' => 'test_field',
+                ),
+                'expected'            => false,
+            ),
+        );
+
+        foreach ( $test_cases as $case ) {
+            // テスト関数実行
+            $actual = vk_dynamic_if_block_has_request_state_condition($case['attributes']);
+
+            // 期待値テスト
+            $this->assertSame($case['expected'], $actual, $case['test_condition_name']);
+        }
+    }
+
 }

--- a/tests/test-dynamic-if.php
+++ b/tests/test-dynamic-if.php
@@ -2694,7 +2694,7 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
     /**
      * リクエスト状態に依存する条件が含まれるかの判定テスト
      *
-     * 端末種別・ログイン状態・ユーザー権限・時刻に依存する条件を含む場合、
+     * 端末種別・ログイン状態・ユーザー権限・時刻・言語に依存する条件を含む場合、
      * 表示判定の結果をリクエストをまたいでキャッシュしてはいけないため true を返す。
      */
     public function test_vk_dynamic_if_block_has_request_state_condition()
@@ -3053,9 +3053,12 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
             ),
         );
 
+        // 端末種別の条件を含むケースが PC 環境であることを前提にしているため、明示的に固定する
+        add_filter('wp_is_mobile', '__return_false');
+
         foreach ( $test_cases as $case ) {
-            // レンダー関数と同じ計算式でキャッシュキーを組み立てる
-            $cache_key = 'vk_dynamic_if_block_' . md5(serialize($case['attributes']) . serialize($content) . get_the_ID() . get_queried_object_id());
+            // レンダー関数と同じヘルパーでキャッシュキーを組み立てる
+            $cache_key = vk_dynamic_if_block_get_cache_key($case['attributes'], $content, 'vk_dynamic_if_block_');
 
             // 前のケースの残りを消してから仕込む
             wp_cache_delete($cache_key, 'vk_dynamic_if_block');
@@ -3081,6 +3084,8 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
             // 後始末
             wp_cache_delete($cache_key, 'vk_dynamic_if_block');
         }
+
+        remove_all_filters('wp_is_mobile');
     }
 
     /**
@@ -3150,9 +3155,12 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
         // 未ログイン状態であることを保証する（ログインユーザー条件のケースの前提）
         wp_set_current_user(0);
 
+        // 端末種別の条件を含むケースが PC 環境であることを前提にしているため、明示的に固定する
+        add_filter('wp_is_mobile', '__return_false');
+
         foreach ( $test_cases as $case ) {
-            // レンダー関数と同じ計算式でキャッシュキーを組み立てる
-            $cache_key = 'vk_dynamic_if_block_old_' . md5(serialize($case['attributes']) . serialize($content) . get_the_ID() . get_queried_object_id());
+            // レンダー関数と同じヘルパーでキャッシュキーを組み立てる
+            $cache_key = vk_dynamic_if_block_get_cache_key($case['attributes'], $content, 'vk_dynamic_if_block_old_');
 
             // 前のケースの残りを消してから仕込む
             wp_cache_delete($cache_key, 'vk_dynamic_if_block');
@@ -3178,6 +3186,8 @@ class VkDynamicIfBlockRenderTest extends WP_UnitTestCase
             // 後始末
             wp_cache_delete($cache_key, 'vk_dynamic_if_block');
         }
+
+        remove_all_filters('wp_is_mobile');
     }
 
 }


### PR DESCRIPTION
Closes #137

## 概要

Dynamic If ブロックは、表示するかどうかの判定結果を約60秒間キャッシュしています。このキャッシュのキー（結果を出し入れするときの目印）が、**リクエストごとに変わる状態を含んでいませんでした**。キーは「ブロックの設定 + ブロックの中身 + 表示中の投稿 ID + クエリ対象 ID」だけで作られており、端末がスマホか PC か、閲覧者がログインしているか、といった情報が入っていません。

そのため、**永続オブジェクトキャッシュ（Redis / Memcached など、リクエストをまたいで値が残る仕組み）を使っている環境**では、先にアクセスした人向けの判定結果が、直後にアクセスした別条件の人にもそのまま返る可能性がありました。

この PR は、**リクエストごとに変わる条件を含むブロックについては、キャッシュを使わない**ようにします。

## 対象の条件

| 条件 | リクエストごとに変わる理由 |
|---|---|
| デバイスの種類（`mobileDevice`） | `wp_is_mobile()` が閲覧者の端末で変わる |
| ログインユーザー（`loginUser`） | `is_user_logged_in()` が閲覧者で変わる |
| ユーザー権限（`userRole`） | ログイン中のユーザーの権限で変わる |
| 期間指定（`period`） | 現在時刻で変わる |
| 言語（`language`） | `get_locale()` が多言語プラグイン（WPML / Polylang 等）の環境で閲覧者ごとに変わる |

これらを含まないブロック（`pageType` / `postType` / `taxonomy` など、表示中のページに紐づく条件のみのブロック）は、**従来どおりキャッシュを使います**。性能面の後退を避けるためです。

## 実装

- 対象の条件タイプ一覧を `vk_dynamic_if_block_get_request_state_condition_types()` に集約し、条件が増えたときの修正点を1か所にまとめました
- 判定は入れ子の条件（`conditions` の中の `conditions`）も**再帰的に**見ます。入れ子の中にだけ対象条件がある場合も取りこぼしません
- 旧形式の属性（`showOnlyMobileDevice` / `showOnlyLoginUser` / `userRole` / `periodDisplaySetting` / `ifLanguage`）にも同じ判定を用意しました。旧形式は評価のしかたが新形式と異なるため、実際の評価箇所を1つずつ突き合わせて条件を合わせています
- キャッシュキーの生成を `vk_dynamic_if_block_get_cache_key()` へ切り出しました。**生成されるキー文字列は変更前と完全に同一**で、既存のキャッシュとの互換性は保たれています

## テスト

`tests/test-dynamic-if.php` に次を追加しました。

- 判定関数そのものの単体テスト（20ケース。入れ子・旧形式・`'none'` や空値などの境界値を含む）
- **キャッシュが実際に使われない／使われることの振る舞いテスト**（11ケース）。キャッシュに逆の値を仕込んだうえでレンダリングし、対象条件を含む場合はその値が無視されること、含まない場合は従来どおり使われること（後退がないこと）を確認します

## 検証結果

**PHPUnit は未実行です**（後述）。代わりに、永続オブジェクトキャッシュが有効な環境を模擬する PHP スクリプトで、修正前後の挙動を比較しました。1つのプロセス内で「リクエスト1 → リクエスト2」を作り、端末・ログイン状態・権限・言語だけを切り替えて出力を比べています。

| 対象 | 32ケース中の失敗 |
|---|---|
| 修正前（`origin/main` = 149930f） | **15** |
| 修正後 | **0** |

修正前に再現した取り違えの例:

- 端末: リクエスト1がスマホ（表示）→ リクエスト2が PC のとき、**本来は非表示のはずが表示された**
- ログイン状態: リクエスト1がログイン中（表示）→ リクエスト2が未ログインのとき、**表示されたまま**
- ユーザー権限: 管理者向けの内容が、購読者・未ログインの閲覧者にも表示された

修正後はいずれも期待どおりになり、あわせて次も確認しています。

- 対象条件を含むブロックは `wp_cache_set` の呼び出しが **0 回**（キャッシュされない）
- 対象外の条件のみのブロックは、**従来どおりキャッシュが効く**（1回目で保存、2回目はキャッシュヒット）
- 生成されるキャッシュキーが `origin/main` と**完全一致**

## 確認手順

### 前提

- 永続オブジェクトキャッシュ（Redis / Memcached 等）が有効な環境。**WordPress 標準の状態では、キャッシュがリクエストをまたいで残らないため、この不具合は再現しません**

### 修正前の再現（Before）

1. 固定ページに Dynamic If ブロックを置き、条件に「デバイスの種類 > モバイルのみ」を設定して、中に「スマホ向け」と書いたブロックを入れる
2. ページを公開する
3. スマートフォン（またはブラウザの開発者ツールでモバイル表示）でそのページを開く
   → 「スマホ向け」が表示される
4. **60秒以内に**、PC のブラウザで同じページを開く
   → **本来は非表示のはずの「スマホ向け」が表示される**（これが不具合）

### 修正後の確認（After）

1. このブランチを適用する
2. 上記 3 → 4 を同じ手順で行う
   → 手順4で「スマホ向け」が**表示されない**（PC では非表示になる）
3. 「ログインユーザー > ログインユーザーのみ」の条件でも同様に確認する
   - ログイン状態でページを開く → 表示される
   - 60秒以内にシークレットウィンドウ（未ログイン）で開く → **表示されない**

### 後退していないことの確認（デグレ確認）

1. 条件に「ページタイプ > フロントページ」だけを設定したブロックを用意する
2. フロントページを開く → 表示される
3. 個別投稿ページを開く → 表示されない
   → 従来どおり出し分けができていれば OK です（この条件はキャッシュ対象のままです）

## 注意点

- **PHPUnit は未実行です。** 作業環境の Docker が「利用できるネットワークのアドレス範囲を使い切った」状態で wp-env を起動できず、実行できませんでした。CI が回せる環境でこのブランチを通す際は、追加した3メソッド（`test_vk_dynamic_if_block_has_request_state_condition` / `test_vk_dynamic_if_block_render_conditions` / `test_vk_dynamic_if_block_render_old_attributes`）の結果を最初に確認してください
- **ブラウザでの実表示確認も未実施です**（同じ理由）。上記の検証は PHP レベルの比較によるものです
- キャッシュキーが検索結果・404・アーカイブを区別できない点（`get_the_ID()` と `get_queried_object_id()` がどちらも得られないページ同士でキーが一致する）は、**今回のスコープ外**です。キーの作り方そのものを変える必要があり、今回採用した方針（依存条件があればキャッシュしない）とは別の設計判断になるためです。新しく追加したヘルパーの docblock に、この制約を注記として残しています
- 「言語」を対象に加えたのは、レビューで漏れが判明したためです。当初の実装では対象外で、検証でも実際に4件の取り違えが再現していました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * デバイス種別、ログイン状態、ユーザー権限、表示期間、言語などに応じた表示判定が、誤ったキャッシュ結果を使用しないよう改善しました。
  * リクエストごとに変化する条件を含む場合はキャッシュを無効化し、それ以外の条件では従来どおりキャッシュを利用します。
  * 新旧形式の条件や、複数の条件を組み合わせた表示判定にも対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->